### PR TITLE
Install tab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+CURPATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+CURDIR := $(notdir $(patsubst %/,%,$(dir $(CURPATH))))
+
 phpcs:
 	~/.composer/vendor/bin/phpcs --standard=phpcs.ruleset.xml
 
@@ -13,10 +16,10 @@ rebuild:
 	docker-compose build --no-cache
 
 install:
-	docker exec disquswordpressplugin_wordpress_1 wp core install --url='localhost:8888' --title='Example' --admin_user='admin' --admin_password='root' --admin_email='admin@example.com'
+	docker exec ${CURDIR}_wordpress_1 wp core install --url='localhost:8888' --title='Example' --admin_user='admin' --admin_password='root' --admin_email='admin@example.com'
 
 activate:
-	docker exec disquswordpressplugin_wordpress_1 wp plugin activate disqus
+	docker exec ${CURDIR}_wordpress_1 wp plugin activate disqus
 
 js:
 	yarn run build

--- a/frontend/src/ts/components/Admin.tsx
+++ b/frontend/src/ts/components/Admin.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as ReactRedux from 'react-redux';
 import * as Redux from 'redux';
 import {
+    InstallContainer,
     SiteConfigContainer,
     SSOConfigContainer,
     SupportDiagnosticsContainer,
@@ -9,7 +10,6 @@ import {
 } from '../containers';
 import { IAdminState } from '../reducers/AdminState';
 import { getForumAdminUrl, getWordpressAdminUrl } from '../utils';
-import AdminCard from './AdminCard';
 import { IFormProps } from './FormProps';
 import SupportLinks from './SupportLinks';
 import WelcomePanel from './WelcomePanel';
@@ -48,12 +48,18 @@ const getSyncContainer = (props: IFormProps) => {
 };
 
 const getTabClassName = (props: IFormProps, id: string) => {
-    const activeTab = props.data.activeTab || 'siteConfiguration';
+    const activeTab = props.data.activeTab || (props.data.adminOptions.disqus_installed ? 'siteConfiguration' : 'install');
     return `nav-tab${activeTab === id ? ' nav-tab-active' : ''}`;
 };
 
 const AdminTabBar = (props: IFormProps) => (
     <div className='nav-tab-wrapper'>
+        {props.data.adminOptions.disqus_installed ?
+            null :
+            <a href="#install" className={getTabClassName(props, 'install')}>
+                {__('Install')}
+            </a>
+        }
         <a href='#siteConfiguration' className={getTabClassName(props, 'siteConfiguration')}>
             {__('Site Configuration')}
         </a>
@@ -134,6 +140,8 @@ const getActiveTabView = (props: IFormProps) => {
                 </div>
             </div>
         );
+    case 'install':
+        return <InstallContainer />;
     case 'siteConfiguration':
     default:
         return (

--- a/frontend/src/ts/components/Admin.tsx
+++ b/frontend/src/ts/components/Admin.tsx
@@ -16,13 +16,13 @@ import WelcomePanel from './WelcomePanel';
 
 const getSSOContainer = (props: IFormProps) => {
     const adminOptions = props.data.adminOptions;
-    if (!adminOptions.disqus_public_key || !adminOptions.disqus_secret_key) {
+    if (!adminOptions.disqus_public_key || !adminOptions.disqus_secret_key || !adminOptions.disqus_installed) {
         return (
             <div className='notice notice-warning'>
                 <p>
                     <span className='dashicons dashicons-warning' />
                     {' '}
-                    {__('You must have an API Public Key and API Secret Key configured to enable this feature.')}
+                    {__('You must have a Site Shortname, API Public Key, and API Secret Key configured to enable this feature.')}
                 </p>
             </div>
         );
@@ -32,13 +32,13 @@ const getSSOContainer = (props: IFormProps) => {
 
 const getSyncContainer = (props: IFormProps) => {
     const adminOptions = props.data.adminOptions;
-    if (!adminOptions.disqus_secret_key || !adminOptions.disqus_admin_access_token) {
+    if (!adminOptions.disqus_secret_key || !adminOptions.disqus_admin_access_token || !adminOptions.disqus_installed) {
         return (
             <div className='notice notice-warning'>
                 <p>
                     <span className='dashicons dashicons-warning' />
                     {' '}
-                    {__('You must have an API Secret Key and API Access Token configured to enable this feature.')}
+                    {__('You must have a Site Shortname, API Secret Key, and API Access Token configured to enable this feature.')}
                 </p>
             </div>
         );
@@ -58,7 +58,7 @@ const getTabClassName = (props: IFormProps, id: string) => {
 
 const AdminTabBar = (props: IFormProps) => (
     <div className='nav-tab-wrapper'>
-        <a href="#install" className={getTabClassName(props, 'install')}>
+        <a href='#install' className={getTabClassName(props, 'install')}>
             {props.data.adminOptions.disqus_installed ? __('Reinstall') : __('Install')}
         </a>
         <a href='#siteConfiguration' className={getTabClassName(props, 'siteConfiguration')}>
@@ -169,7 +169,10 @@ const getActiveTabView = (props: IFormProps) => {
 
 const Admin = (props: IFormProps) => (
     <div>
-        <WelcomePanel shortname={props.data.adminOptions.disqus_forum_url} />
+        {props.data.adminOptions.disqus_installed ?
+            <WelcomePanel shortname={props.data.adminOptions.disqus_forum_url} /> :
+            null
+        }
         <AdminTabBar {...props} />
         {getActiveTabView(props)}
     </div>

--- a/frontend/src/ts/components/Admin.tsx
+++ b/frontend/src/ts/components/Admin.tsx
@@ -47,19 +47,20 @@ const getSyncContainer = (props: IFormProps) => {
     return <SyncConfigContainer />;
 };
 
+const getActiveTab = (props: IFormProps) => (
+    props.data.activeTab || (props.data.adminOptions.disqus_installed ? 'siteConfiguration' : 'install')
+);
+
 const getTabClassName = (props: IFormProps, id: string) => {
-    const activeTab = props.data.activeTab || (props.data.adminOptions.disqus_installed ? 'siteConfiguration' : 'install');
+    const activeTab = getActiveTab(props);
     return `nav-tab${activeTab === id ? ' nav-tab-active' : ''}`;
 };
 
 const AdminTabBar = (props: IFormProps) => (
     <div className='nav-tab-wrapper'>
-        {props.data.adminOptions.disqus_installed ?
-            null :
-            <a href="#install" className={getTabClassName(props, 'install')}>
-                {__('Install')}
-            </a>
-        }
+        <a href="#install" className={getTabClassName(props, 'install')}>
+            {props.data.adminOptions.disqus_installed ? __('Reinstall') : __('Install')}
+        </a>
         <a href='#siteConfiguration' className={getTabClassName(props, 'siteConfiguration')}>
             {__('Site Configuration')}
         </a>
@@ -77,7 +78,8 @@ const AdminTabBar = (props: IFormProps) => (
 
 /* tslint:disable:max-line-length */
 const getActiveTabView = (props: IFormProps) => {
-    switch (props.data.activeTab) {
+    const activeTab = getActiveTab(props);
+    switch (activeTab) {
     case 'syncingImporting':
         return (
             <div>

--- a/frontend/src/ts/components/Install.tsx
+++ b/frontend/src/ts/components/Install.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react';
-import * as ReactRedux from 'react-redux';
-import { SiteConfigContainer, SupportDiagnosticsContainer } from '../containers';
-import { IAdminState, InstallationState } from '../reducers/AdminState';
+import { InstallationState } from '../reducers/AdminState';
 import { IDisqusWordpressWindow } from '../reducers/AdminState';
-import { getWordpressAdminUrl } from '../utils';
-import AdminCard from './AdminCard';
 import { IFormProps } from './FormProps';
-import SupportLinks from './SupportLinks';
 
 const WIN = window as IDisqusWordpressWindow;
 const REST_OPTIONS = WIN.DISQUS_WP.rest;
@@ -24,51 +19,13 @@ class Install extends React.Component<IFormProps, any> {
         const syncToken = `${REST_OPTIONS.base}settings ${this.props.data.adminOptions.get('disqus_sync_token', '')}`;
         return (
             <div>
-                <AdminCard title={__('Automatic Installation')}>
-                    <p>
-                        {__('Installs Disqus on your site using a generated API application. If your site isn\'t publicly accessible, use the manual installation method.')}
-                    </p>
-                    {this.getAutoInstallPrompt(syncToken)}
-                </AdminCard>
-                <AdminCard title={__('Manual Installation')}>
-                    <p>
-                        {__('You may install Disqus manually if you\'re not able to use the automatic installer.')}
-                    </p>
-                    <p className='submit'>
-                        <button className='button button-link' onClick={this.props.onToggleState.bind(null, 'isSiteFormLocked')}>
-                            <span className={`dashicons dashicons-arrow-${this.props.data.isSiteFormLocked ? 'right' : 'down'}`} />
-                            {' '}
-                            {this.props.data.isSiteFormLocked ? __('Show manual configuration') : __('Hide manual configuration')}
-                        </button>
-                    </p>
-                    {this.props.data.isSiteFormLocked ? null : <SiteConfigContainer />}
-                </AdminCard>
-                <AdminCard title={__('WordPress Comments')}>
-                    <p className='description'>
-                        {__('Disqus has replaced the default WordPress commenting system. You may access and edit the comments in your database, but any actions performed there will not be reflected in Disqus.')}
-                    </p>
-                    <p className='submit'>
-                        <a
-                            href={getWordpressAdminUrl('editComments')}
-                            className='button'
-                        >
-                            {__('View WordPress Comments')}
-                        </a>
-                    </p>
-                </AdminCard>
-                <AdminCard title={__('Support')}>
-                    <SupportLinks />
-                    <hr />
-                    <h3>
-                        {__('Diagnostic Information')}
-                    </h3>
-                    <p className='description'>
-                        {__('Include the following information in any private support requests, but do not share this publicly.')}
-                    </p>
-                    <div className='submit'>
-                        <SupportDiagnosticsContainer />
-                    </div>
-                </AdminCard>
+                <h3>
+                    {__('Automatic Installation')}
+                </h3>
+                <p>
+                    {__('Installs Disqus on your site using a generated API application. If your site isn\'t publicly accessible, use the manual installation method.')}
+                </p>
+                {this.getAutoInstallPrompt(syncToken)}
             </div>
         );
     }

--- a/frontend/src/ts/components/Main.tsx
+++ b/frontend/src/ts/components/Main.tsx
@@ -12,8 +12,6 @@ const getMainView = (props: IFormProps) => {
         return __('You don\'t have permission to make any changes here. Please contact the site administrator to get access.');
     else if (props.data.isFetchingAdminOptions || props.data.isFetchingSyncStatus)
         return <Loading />;
-    else if (!props.data.adminOptions.disqus_installed)
-        return <InstallContainer />;
     return <Admin {...props} />;
 };
 


### PR DESCRIPTION
Updated the uninstalled state to use the new tabbed interface. Added an install/reinstall tab, removed old code path for uninstalled state.

Not sure if anything different needs to be done for the "reinstall" automatic installation flow if already installed.