### PR TITLE
Update support link url

### DIFF
--- a/frontend/src/ts/components/SupportLinks.tsx
+++ b/frontend/src/ts/components/SupportLinks.tsx
@@ -27,7 +27,7 @@ const SupportLinks = () => (
         <li className='dsq-support-list-item'>
             <div>
                 <a
-                    href='https://disqus.com/support/?article=contact_wordpress'
+                    href='http://wp-plugin.disqus.net/'
                     target='_blank'
                 >
                     <div className='dashicons dashicons-email-alt dsq-icon-support' />

--- a/frontend/tests/components/__snapshots__/SupportLinks.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/SupportLinks.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`SupportLinks renders with correct links 1`] = `
   >
     <div>
       <a
-        href="https://disqus.com/support/?article=contact_wordpress"
+        href="http://wp-plugin.disqus.net/"
         target="_blank"
       >
         <div


### PR DESCRIPTION
This allows us to redirect the support link to different tools/channels in the future without needing a plugin update.