### PR TITLE
Fix avatar sync for a SSO

### DIFF
--- a/disqus/public/class-disqus-public.php
+++ b/disqus/public/class-disqus-public.php
@@ -58,7 +58,7 @@ class Disqus_Public {
 		if ( $user->ID ) {
 			$payload_user['id'] = $user->ID;
 			$payload_user['username'] = $user->display_name;
-			$payload_user['avatar'] = get_avatar( $user->ID, 92 );
+			$payload_user['avatar'] = get_avatar_url( $user->ID, 92 );
 			$payload_user['email'] = $user->user_email;
 			$payload_user['url'] = $user->user_url;
 		}


### PR DESCRIPTION
Working on the web "http://nintenderos.com" we were having an avatars synchronization problem. Reading the official documentation of Disqus I observed that the value of the parameter that is required in the configuration "avatar" is a url and the function that currently exists `get_avatar()` returns `<img src="...">` when it should return a string with a url.

_Image with Disqus documentation:_
![image](https://user-images.githubusercontent.com/1427623/40071375-e4e96d2a-5870-11e8-9f59-d23e1a74c305.png)

I have modified the function by `get_avatar_url()` so that it always returns the url of the avatar, so when the avatar value is updated it will show the new avatar.