### PR TITLE
FIX: "Undefined index: HTTP_HOST" for no web server

### DIFF
--- a/disqus/admin/class-disqus-admin.php
+++ b/disqus/admin/class-disqus-admin.php
@@ -164,7 +164,7 @@ class Disqus_Admin {
             $rest_host .= ':' . $rest_url_parts['port'];
         }
 
-        $current_host = $_SERVER['HTTP_HOST'];
+        $current_host = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : $rest_host;
 
         if ( $rest_host !== $current_host ) {
             $rest_url = preg_replace( '/' . $rest_host . '/', $current_host, $rest_url, 1 );

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -42,4 +42,18 @@ class Test_Admin extends WP_UnitTestCase {
         $_SERVER['HTTP_HOST'] = $previous_host;
     }
 
+    /**
+     * Ensure that REST URL filter will not error when HTTP_HOST is undefined.
+     */
+    function test_dsq_filter_rest_url_no_host() {
+        $admin = new Disqus_Admin( 'disqus', '0.0.0', 'foo' );
+        $previous_host = $_SERVER['HTTP_HOST'];
+        $_SERVER['HTTP_HOST'] = NULL;
+        $init_url = 'https://example.org/wp-json/disqus/v1';
+
+        $rest_url = $admin->dsq_filter_rest_url($init_url);
+
+        $this->assertEquals( $init_url, $rest_url );
+    }
+
 }


### PR DESCRIPTION
- Added a null guard for the `dsq_filter_rest_url` 
- Added functionality tests to ensure `dsq_filter_rest_url` does not error when` _SERVER` host is not set.

Address: https://github.com/disqus/disqus-wordpress-plugin/issues/57