### PR TITLE
Comments showing sync date instead of creation date in wordpress admin

### DIFF
--- a/disqus/rest-api/class-disqus-rest-api.php
+++ b/disqus/rest-api/class-disqus-rest-api.php
@@ -806,6 +806,7 @@ class Disqus_Rest_Api {
             'comment_author_IP' => $post['ipAddress'],
             'comment_author_url' => isset( $author['url'] ) ? $author['url'] : '',
             'comment_content' => $post['raw_message'],
+            'comment_date' => $post['createdAt'],
             'comment_date_gmt' => $post['createdAt'],
             'comment_type' => '', // Leave blank for a regular comment.
             'comment_parent' => $parent,


### PR DESCRIPTION
Seeing that the date reflected in wordpress admin is showing `comment_date` rather than what we are setting `comment_date_gmt`. When `comment_date` is not passed the current datetime is used instead.
It is recommended in the docs when setting `comment_date` manually to also set `comment_date_gmt` which we have been doing.
https://developer.wordpress.org/reference/functions/wp_insert_comment/

Confirmed locally and in the admin that our comment `created_at` datetime is being set for both fields.
<img width="564" alt="Screen Shot 2020-12-15 at 11 51 34 AM" src="https://user-images.githubusercontent.com/12240845/102265488-069af080-3ecc-11eb-991a-6ab0253c5a13.png">
<img width="594" alt="Screen Shot 2020-12-15 at 11 38 44 AM" src="https://user-images.githubusercontent.com/12240845/102265494-07cc1d80-3ecc-11eb-8d82-32883056cb13.png">
<img width="987" alt="Screen Shot 2020-12-15 at 11 38 33 AM" src="https://user-images.githubusercontent.com/12240845/102265500-08fd4a80-3ecc-11eb-931d-e316b223b77f.png">
