### PR TITLE
Fix Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 
 language: php
 
+services: mysql
+
 notifications:
   email:
     on_success: never
@@ -9,8 +11,7 @@ notifications:
 
 php:
   - 5.4
-  - 7.0
-  - 7.1
+  - 7.2
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
@@ -21,16 +22,16 @@ matrix:
       env: WP_VERSION=4.4 WP_MULTISITE=0
     - php: 5.4
       env: WP_VERSION=latest WP_MULTISITE=1
+    - php: 7.2
+      env: WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
   - |
-    if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
-      composer global require "phpunit/phpunit=6.*"
-    elif [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-      composer global require "phpunit/phpunit=7.*"
+    if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then
+      composer global require "phpunit/phpunit=^7"
     else
-      composer global require "phpunit/phpunit=4.8.*"
+      composer global require "phpunit/phpunit=^4"
     fi
   - |
   - composer install
@@ -52,4 +53,4 @@ deploy:
   script: sh bin/deploy.sh
   on:
     branch: master
-    php: 7.0
+    php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,18 @@ php:
   - 5.4
   - 7.2
 
-dist: trusty
-
-env:
-  - WP_VERSION=latest WP_MULTISITE=0
-
 matrix:
   include:
     - php: 5.4
+      # PHP v5.4 isn't supported in the default build environment
+      # Only use Trusty environment for v5.4 builds because it increases queue time
+      dist: trusty
       env: WP_VERSION=4.4 WP_MULTISITE=0
     - php: 5.4
-      env: WP_VERSION=latest WP_MULTISITE=1
+      dist: trusty
+      env: WP_VERSION=4.4 WP_MULTISITE=1
+    - php: 7.2
+      env: WP_VERSION=latest WP_MULTISITE=0
     - php: 7.2
       env: WP_VERSION=latest WP_MULTISITE=1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
 
 script:
   - ./vendor/bin/phpcs -s --standard=phpcs.ruleset.xml
-  - ./bin/test.sh
+  - bash bin/test.sh
   - yarn run build
   - npm test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
     if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
       composer global require "phpunit/phpunit=6.5.*"
     elif [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-      composer global require "phpunit/phpunit=7.5.*"g
+      composer global require "phpunit/phpunit=7.5.*"
     else
       composer global require "phpunit/phpunit=4.8.*"
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ php:
   - 5.4
   - 7.2
 
+dist: trusty
+
 env:
   - WP_VERSION=latest WP_MULTISITE=0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,11 @@ before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
   - |
     if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]]; then
-      composer global require "phpunit/phpunit=4.8.*"
+      composer global require "phpunit/phpunit:4.8"
     elif [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
-      composer global require "phpunit/phpunit=6.5.*"
+      composer global require "phpunit/phpunit:6.5"
     else
-      composer global require "phpunit/phpunit=7.*"
+      composer global require "phpunit/phpunit:7.5"
     fi
   - |
   - composer install --no-interaction

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,21 @@ php:
   - 5.4
   - 7.0
   - 7.1
+  - 7.4
 
 env:
-  - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=4.4 WP_MULTISITE=0
 
 matrix:
   include:
     - php: 5.4
-      env: WP_VERSION=4.4 WP_MULTISITE=0
-    - php: 5.4
       env: WP_VERSION=latest WP_MULTISITE=1
+    - php: 7.0
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: 7.1
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: 7.4
+      env: WP_VERSION=latest WP_MULTISITE=0
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
@@ -33,7 +38,7 @@ before_script:
     if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
       composer global require "phpunit/phpunit=6.5.*"
     elif [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-      composer global require "phpunit/phpunit=7.5.*"
+      composer global require "phpunit/phpunit=7.5.*"g
     else
       composer global require "phpunit/phpunit=4.8.*"
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ notifications:
 
 php:
   - 5.4
-  - 7.2
+  - 7.4
 
 matrix:
   include:
@@ -23,15 +23,15 @@ matrix:
     - php: 5.4
       dist: trusty
       env: WP_VERSION=4.4 WP_MULTISITE=1
-    - php: 7.2
+    - php: 7.4
       env: WP_VERSION=latest WP_MULTISITE=0
-    - php: 7.2
+    - php: 7.4
       env: WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
   - |
-    if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then
+    if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]]; then
       composer global require "phpunit/phpunit=^7"
     else
       composer global require "phpunit/phpunit=^4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
 
 deploy:
   provider: script
-  skip_cleanup: true
+  cleanup: false
   script: sh bin/deploy.sh
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,26 +18,32 @@ php:
   - 7.3
 
 env:
-  - WP_VERSION=latest WP_MULTISITE=0
-  - WP_VERSION=latest WP_MULTISITE=1
+  - WP_VERSION=latest
 
 jobs:
   include:
     # Canary for our oldest-supported version
-    - name: Legacy
-      # PHP v5.6 is the oldest version Wordpress supports
-      php: 5.6
-      env: WP_VERSION=4.4 WP_MULTISITE=0
+    # PHP v5.6 is the oldest version Wordpress supports
+    - php: 5.6
+      env: WP_VERSION=4.4
+
+# Enable dependency caching
+cache:
+  apt: true
+  directories:
+    - vendor
+    - $HOME/.npm
+    - $HOME/.composer/cache
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
   - |
-    if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
-      composer global require "phpunit/phpunit=6.5.*"
-    elif [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-      composer global require "phpunit/phpunit=7.5.*"
-    else
+    if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]]; then
       composer global require "phpunit/phpunit=4.8.*"
+    elif [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
+      composer global require "phpunit/phpunit=6.5.*"
+    else
+      composer global require "phpunit/phpunit=7.*"
     fi
   - |
   - composer install --no-interaction
@@ -49,7 +55,7 @@ before_script:
 
 script:
   - ./vendor/bin/phpcs -s --standard=phpcs.ruleset.xml
-  - phpunit
+  - ./bin/test.sh
   - yarn run build
   - npm test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ notifications:
     on_success: never
     on_failure: change
 
+# PHP v5.4 isn't supported in the default build environment
+dist: trusty
+
 php:
   - 5.4
   - 7.0
@@ -20,21 +23,17 @@ env:
 matrix:
   include:
     - php: 5.4
-      # PHP v5.4 isn't supported in the default build environment
-      # Only use Trusty environment for v5.4 builds because it increases queue time
-      dist: trusty
       env: WP_VERSION=4.4 WP_MULTISITE=0
     - php: 5.4
-      dist: trusty
       env: WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
   - |
     if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
-      composer global require "phpunit/phpunit=6.*"
+      composer global require "phpunit/phpunit=6.5.*"
     elif [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-      composer global require "phpunit/phpunit=7.*"
+      composer global require "phpunit/phpunit=7.5.*"
     else
       composer global require "phpunit/phpunit=4.8.*"
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,11 @@ before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
   - |
     if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]]; then
-      composer global require "phpunit/phpunit:4.8"
+      composer require phpunit/phpunit "^4.8"
     elif [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
-      composer global require "phpunit/phpunit:6.5"
+      composer require phpunit/phpunit "^6.5"
     else
-      composer global require "phpunit/phpunit:7.5"
+      composer require phpunit/phpunit "^7.5"
     fi
   - |
   - composer install --no-interaction

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+os: linux
 
 language: php
 
@@ -22,7 +22,7 @@ php:
 env:
   - WP_VERSION=latest WP_MULTISITE=0
 
-matrix:
+jobs:
   include:
     - php: 5.6
       env: WP_VERSION=4.4 WP_MULTISITE=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,11 @@ notifications:
 
 php:
   - 5.4
-  - 7.4
+  - 7.0
+  - 7.1
+
+env:
+  - WP_VERSION=latest WP_MULTISITE=0
 
 matrix:
   include:
@@ -22,19 +26,17 @@ matrix:
       env: WP_VERSION=4.4 WP_MULTISITE=0
     - php: 5.4
       dist: trusty
-      env: WP_VERSION=4.4 WP_MULTISITE=1
-    - php: 7.4
-      env: WP_VERSION=latest WP_MULTISITE=0
-    - php: 7.4
       env: WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
   - |
-    if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]]; then
-      composer global require "phpunit/phpunit=^7"
+    if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
+      composer global require "phpunit/phpunit=6.*"
+    elif [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
+      composer global require "phpunit/phpunit=7.*"
     else
-      composer global require "phpunit/phpunit=^4"
+      composer global require "phpunit/phpunit=4.8.*"
     fi
   - |
   - composer install
@@ -56,4 +58,4 @@ deploy:
   script: sh bin/deploy.sh
   on:
     branch: master
-    php: 7.1
+    php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,28 +9,25 @@ notifications:
     on_success: never
     on_failure: change
 
-# PHP v5.4 isn't supported in the default build environment
+# PHP v5.6 isn't supported in the default build environment
 dist: trusty
 
 php:
-  - 5.4
+  # PHP v5.6 is the oldest version Wordpress supports
+  - 5.6
   - 7.0
   - 7.1
   - 7.4
 
 env:
-  - WP_VERSION=4.4 WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=0
 
 matrix:
   include:
-    - php: 5.4
+    - php: 5.6
+      env: WP_VERSION=4.4 WP_MULTISITE=0
+    - php: 5.6
       env: WP_VERSION=latest WP_MULTISITE=1
-    - php: 7.0
-      env: WP_VERSION=latest WP_MULTISITE=0
-    - php: 7.1
-      env: WP_VERSION=latest WP_MULTISITE=0
-    - php: 7.4
-      env: WP_VERSION=latest WP_MULTISITE=0
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,25 +9,25 @@ notifications:
     on_success: never
     on_failure: change
 
-# PHP v5.6 isn't supported in the default build environment
+# PHP v5.x isn't supported in the default build environment
 dist: trusty
 
 php:
-  # PHP v5.6 is the oldest version Wordpress supports
-  - 5.6
   - 7.0
   - 7.1
-  - 7.4
+  - 7.3
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=1
 
 jobs:
   include:
-    - php: 5.6
+    # Canary for our oldest-supported version
+    - name: Legacy
+      # PHP v5.6 is the oldest version Wordpress supports
+      php: 5.6
       env: WP_VERSION=4.4 WP_MULTISITE=0
-    - php: 5.6
-      env: WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
@@ -40,7 +40,7 @@ before_script:
       composer global require "phpunit/phpunit=4.8.*"
     fi
   - |
-  - composer install
+  - composer install --no-interaction
   - nvm install --lts
   - nvm use --lts
   - npm install -g yarn

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -4,8 +4,8 @@
 
 # Run single-site unit tests
 export WP_MULTISITE=0
-phpunit --exclude-group=ms-required
+./vendor/bin/phpunit  --exclude-group=ms-required
 
 # Run Multisite unit tests
 export WP_MULTISITE=1
-phpunit --exclude-group=ms-excluded
+./vendor/bin/phpunit  --exclude-group=ms-excluded

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Run PHPUnit with and without multisite enabled to prevent the need for
+# multiple CI builds
+
+# Run single-site unit tests
+export WP_MULTISITE=0
+phpunit --exclude-group=ms-required
+
+# Run Multisite unit tests
+export WP_MULTISITE=1
+phpunit --exclude-group=ms-excluded

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     "type": "wordpress-plugin",
     "require": {
         "php": ">=5.4.0",
-        "composer/installers": "v1.2.0"
+        "composer/installers": "v1.9.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0.2",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "wp-coding-standards/wpcs": "^0.14.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,35 +1,38 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8a92962c5df6d5e206f1c1b4898827f7",
+    "content-hash": "17d91f51fe9bba5f0f0199edcb793538",
     "packages": [
         {
             "name": "composer/installers",
-            "version": "v1.2.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "d78064c68299743e0161004f2de3a0204e33b804"
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/d78064c68299743e0161004f2de3a0204e33b804",
-                "reference": "d78064c68299743e0161004f2de3a0204e33b804",
+                "url": "https://api.github.com/repos/composer/installers/zipball/b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0"
+                "composer-plugin-api": "^1.0 || ^2.0"
             },
             "replace": {
                 "roundcube/plugin-installer": "*",
                 "shama/baton": "*"
             },
             "require-dev": {
-                "composer/composer": "1.0.*@dev",
-                "phpunit/phpunit": "4.1.*"
+                "composer/composer": "1.6.* || 2.0.*@dev",
+                "composer/semver": "1.0.* || 2.0.*@dev",
+                "phpunit/phpunit": "^4.8.36",
+                "sebastian/comparator": "^1.2.4",
+                "symfony/process": "^2.3"
             },
             "type": "composer-plugin",
             "extra": {
@@ -59,15 +62,22 @@
             "keywords": [
                 "Craft",
                 "Dolibarr",
+                "Eliasis",
                 "Hurad",
                 "ImageCMS",
+                "Kanboard",
+                "Lan Management System",
                 "MODX Evo",
+                "MantisBT",
                 "Mautic",
+                "Maya",
                 "OXID",
                 "Plentymarkets",
+                "Porto",
                 "RadPHP",
                 "SMF",
                 "Thelia",
+                "Whmcs",
                 "WolfCMS",
                 "agl",
                 "aimeos",
@@ -82,28 +92,38 @@
                 "croogo",
                 "dokuwiki",
                 "drupal",
+                "eZ Platform",
                 "elgg",
                 "expressionengine",
                 "fuelphp",
                 "grav",
                 "installer",
+                "itop",
                 "joomla",
+                "known",
                 "kohana",
                 "laravel",
+                "lavalite",
                 "lithium",
                 "magento",
+                "majima",
                 "mako",
                 "mediawiki",
                 "modulework",
+                "modx",
                 "moodle",
+                "osclass",
                 "phpbb",
                 "piwik",
                 "ppi",
                 "puppet",
+                "pxcms",
                 "reindex",
                 "roundcube",
                 "shopware",
                 "silverstripe",
+                "sydes",
+                "sylius",
                 "symfony",
                 "typo3",
                 "wordpress",
@@ -111,35 +131,47 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2016-08-13T20:53:52+00:00"
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-07T06:57:05+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.4.4",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "*"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "wimg/php-compatibility": "^8.0"
-            },
-            "suggest": {
-                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -157,13 +189,13 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "f.nijhof@dealerdirect.nl",
-                    "homepage": "http://workingatdealerdirect.eu",
-                    "role": "Developer"
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://workingatdealerdirect.eu",
+            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -181,20 +213,24 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2017-12-06T16:27:17+00:00"
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.2.2",
+            "version": "3.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1"
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
-                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -204,7 +240,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -227,25 +263,30 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-12-19T21:44:46+00:00"
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.14.0",
+            "version": "0.14.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "8cadf48fa1c70b2381988e0a79e029e011a8f41c"
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "cf6b310caad735816caef7573295f8a534374706"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/8cadf48fa1c70b2381988e0a79e029e011a8f41c",
-                "reference": "8cadf48fa1c70b2381988e0a79e029e011a8f41c",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
+                "reference": "cf6b310caad735816caef7573295f8a534374706",
                 "shasum": ""
             },
             "require": {
@@ -272,7 +313,12 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2017-11-01T15:10:46+00:00"
+            "support": {
+                "issues": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2018-02-16T01:57:48+00:00"
         }
     ],
     "aliases": [],
@@ -281,7 +327,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4.45"
+        "php": ">=5.4.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
  * Updated minimum PHP version from v5.4 to v5.6 because it's now the oldest version that is supported by WordPress
  * Modified CI to use Trusty build environment because Xenial no longer supports PHP v5.x
  * Updated dependency versions in `composer.json` and `composer.lock` to be compatible with Composer v2.0
  * Added PHP v7.3 to the CI build versions
  * Added dependency caching to improve build performance
  * Added `bin/test.sh` to prevent separate CI builds being created for `WP_MULTISITE`
  * Modified the `phpunit` command to use the version that is specified by Composer

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The CI build was broken in every way possible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://travis-ci.org/github/disqus/disqus-wordpress-plugin/builds/753276884

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/disqus/disqus-wordpress-plugin/87)
<!-- Reviewable:end -->
