### PR TITLE
Revert to using skip_cleanup in CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
 
 deploy:
   provider: script
-  cleanup: false
+  skip_cleanup: true
   script: sh bin/deploy.sh
   on:
     branch: master

--- a/disqus/README.txt
+++ b/disqus/README.txt
@@ -3,7 +3,7 @@ Contributors: disqus, alexkingorg, crowdfavorite, zeeg, tail, thetylerhayes, rya
 Tags: disqus, comments, engagement, threaded, email, notification, spam, avatars, community, profile, widget
 Requires at least: 4.4
 Tested up to: 5.6
-Stable tag: 3.0.18
+Stable tag: 3.0.19
 Requires PHP: 5.6
 
 Disqus is the web's most popular comment system. Use Disqus to increase engagement, retain readers, and grow your audience.

--- a/disqus/README.txt
+++ b/disqus/README.txt
@@ -124,6 +124,9 @@ Go to [https://disqus.com/help/wordpress](https://disqus.com/help/wordpress)
 
 == Changelog ==
 
+= 3.0.19 =
+* Fixed issue with missing admin bundles
+
 = 3.0.18 =
 * Tested plugin with WordPress 5.6 and updated documentation
 * Fixed count.js script being loaded on unnecessary pages

--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Disqus for WordPress
  * Plugin URI:        https://disqus.com/
  * Description:       Disqus helps publishers increase engagement and build loyal audiences. Supports syncing comments to your database for easy backup.
- * Version:           3.0.18
+ * Version:           3.0.19
  * Author:            Disqus
  * Author URI:        https://disqus.com/
  * License:           GPL-2.0+
@@ -24,7 +24,7 @@
  * Domain Path:       /languages
  */
 
-$DISQUSVERSION = '3.0.18';
+$DISQUSVERSION = '3.0.19';
 
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.0.19  
+* Fixed issue with missing admin bundles
+
 ### 3.0.18  
 * Tested plugin with WordPress 5.6 and updated documentation
 * Fixed count.js script being loaded on unnecessary pages

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "disqus-wordpress-plugin",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "description": "A WordPress plugin that allows site owners to easily replace the default commenting system with Disqus",
   "main": "frontend/src/js/index.js",
   "scripts": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description  
<!--- Describe your changes in detail -->
Previous changes replaced `skip_cleanup: true` with `cleanup: false` based on a deprecation message from Travis CI, but this appears to have caused issues with our deploy process.

## Motivation and Context  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes an issue where admin bundles aren't being published with the plugin. (Fixes #89)


## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/disqus/disqus-wordpress-plugin/90)
<!-- Reviewable:end -->
