### PR TITLE
Fixed an issue with all comments syncing to one sticky post

### DIFF
--- a/disqus/rest-api/class-disqus-rest-api.php
+++ b/disqus/rest-api/class-disqus-rest-api.php
@@ -734,6 +734,7 @@ class Disqus_Rest_Api {
         $post_query = new WP_Query( array(
             'meta_key' => 'dsq_thread_id',
             'meta_value' => $thread['id'],
+            'ignore_sticky_posts' => true,
         ) );
 
         if ( $post_query->have_posts() ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description  
<!--- Describe your changes in detail -->
Fixed a bug that caused all comments from other posts to sync to the sticky post.

## Motivation and Context  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixed #91 

## How Has This Been Tested?  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added `'ignore_sticky_posts' => true` to the query and started to sync Disqus comments. 
Comments are now added to the correct posts.


## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
