### PR TITLE
Throttle manual comment-sync requests to prevent ERR_INSUFFICIENT_RESOURCES

### DIFF
--- a/disqus/README.txt
+++ b/disqus/README.txt
@@ -124,7 +124,7 @@ Go to [https://disqus.com/help/wordpress](https://disqus.com/help/wordpress)
 
 == Changelog ==
 
-= 3.0.20 =
+= 3.0.21 =
 * Fixed issue with mismatched DISQUSVERSION causing admin issues
 
 = 3.0.20 =

--- a/frontend/src/ts/components/ManualSyncForm.tsx
+++ b/frontend/src/ts/components/ManualSyncForm.tsx
@@ -1,6 +1,5 @@
 import * as moment from 'moment';
 import * as React from 'react';
-import SyncStatus from '../reducers/SyncStatus';
 import { IFormProps } from './FormProps';
 
 const ManualSyncForm = (props: IFormProps) => {
@@ -62,8 +61,25 @@ const ManualSyncForm = (props: IFormProps) => {
                             </p>
                         </td>
                     </tr>
+                    {props.data.syncStatus.is_manual && props.data.syncStatus.progress_message ?
+                        <tr>
+                            <th scope='row'>
+                                <label htmlFor='manualSyncProgress'>
+                                    {__('Progress')}
+                                </label>
+                            </th>
+                            <td>
+                                <span>{props.data.syncStatus.progress_message}</span>
+                            </td>
+                        </tr>
+                    : null}
                 </tbody>
             </table>
+
+            {props.data.syncStatus.is_manual && props.data.syncStatus.last_message ?
+                <p>{props.data.syncStatus.last_message}</p>
+            : null}
+
             <p className='submit'>
                 <button type='submit' className='button button-large' disabled={props.data.isManualSyncRunning}>
                     <span className='dashicons dashicons-update' />

--- a/frontend/src/ts/components/SyncConfigForm.tsx
+++ b/frontend/src/ts/components/SyncConfigForm.tsx
@@ -53,7 +53,9 @@ const SyncConfigForm = (props: IFormProps) => {
                 {' '}
                 <strong>{syncStatus.status}</strong>
             </p>
-            {props.data.syncStatus.last_message ? <p>{props.data.syncStatus.last_message}</p> : null}
+            {!props.data.syncStatus.is_manual && props.data.syncStatus.last_message ?
+                <p>{props.data.syncStatus.last_message}</p>
+            : null}
             <p className='submit'>
                 <button type='submit' className='button button-large'>
                     <span className={`dashicons dashicons-controls-${syncStatus.statusIcon}`} />

--- a/frontend/src/ts/reducers/SyncStatus.ts
+++ b/frontend/src/ts/reducers/SyncStatus.ts
@@ -2,6 +2,8 @@ import { Record } from 'immutable';
 
 export interface ISyncStatus {
     enabled?: boolean;
+    is_manual?: boolean;
+    progress_message?: string;
     last_message?: string;
     requires_update?: any;
     subscribed?: boolean;
@@ -10,6 +12,8 @@ export interface ISyncStatus {
 
 export default class SyncStatus extends Record({
     enabled: null,
+    is_manual: false,
+    progress_message: null,
     last_message: null,
     requires_update: null,
     subscribed: null,
@@ -17,6 +21,8 @@ export default class SyncStatus extends Record({
 }) implements ISyncStatus {
     /* tslint:disable:variable-name */
     public enabled?: boolean;
+    public is_manual?: boolean;
+    public progress_message?: string;
     public last_message?: string;
     public requires_update?: any;
     public subscribed?: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,10 @@
     "compilerOptions": {
         "outDir": "./disqus/admin/js/",
         "sourceMap": true,
+        "skipLibCheck": true,
         "noImplicitAny": true,
         "module": "commonjs",
-        "target": "es5",
+        "target": "es2015",
         "jsx": "react"
     },
     "include": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description  
<!--- Describe your changes in detail -->
We received a report from AndroidPolice that their manual syncing was failing with an `ERR_INSUFFICIENT_RESOURCES` error. This is likely due to the fact that each comment that is synced makes a separate request, so manually syncing large sites could result in >1000 parallel requests.
In response, these changes limit the number of parallel comment-sync requests to 100, which should increase stability but we also expect it to slightly increase the time it takes to manually sync a large number of comments. Because of this, I've also added additional progress logging to the manual-sync process.

Unfortunately, I wasn't able to actually reproduce the `ERR_INSUFFICIENT_RESOURCES` error prior to limiting the requests so I'm assuming that this could have to do with available resources and hardware capabilities, though I did get some comments failing to sync and Danny mentioned that he saw sync requests that were returning 200's but weren't actually getting synced in the WP database.

The reasoning for setting the parallel request limit to 100 was influenced by the initial report citing that they got the `ERR_INSUFFICIENT_RESOURCES` error after a couple of hundred requests were sent, though I'm still open to adjusting this threshold.

There was also a version that was incorrect in the last `disqus/README.txt` changelog update, so I threw that fix in there too.

## Motivation and Context  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Received a report from AndroidPolice that their manual syncing was failing with an `ERR_INSUFFICIENT_RESOURCES` error.

## How Has This Been Tested?  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a production WordPress site with the following workflow:
  1. Change the "Plugin Name" in `disqus/disqus.php` to differentiate from the production plugin
  2. Run `make js && zip -r disqus.zip disqus`
  3. Go to the WP admin and go to Plugins > Add new
  4. Click the "Upload Plugin" button at the top of the page
  5. Upload the zip created in step 2
  6. Deactivate the existing Disqus plugin and activate the newly uploaded version
  7. Go to the Disqus page in the WP admin and click the "Syncing" tab
  8. Click "Manually Sync Comments" and enter a date range containing a >1000 comments
  9. Click "Run Manual Sync"


## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [x] All new and existing tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/disqus/disqus-wordpress-plugin/96)
<!-- Reviewable:end -->
