### PR TITLE
Check for container ID before adding embed script

### DIFF
--- a/disqus/public/js/comment_embed.js
+++ b/disqus/public/js/comment_embed.js
@@ -23,9 +23,11 @@ var disqus_config = function () {
 };
 
 (function() {
-    var dsq = document.createElement('script');
-    dsq.type = 'text/javascript';
-    dsq.async = true;
-    dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
-    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    if (document.getElementById(disqus_container_id)) {
+        var dsq = document.createElement('script');
+        dsq.type = 'text/javascript';
+        dsq.async = true;
+        dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
+        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    }
 })();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description  
<!--- Describe your changes in detail -->
Added a check for the Disqus container before adding the embed script to the page.

## Motivation and Context  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[WP report](https://wordpress.org/support/topic/new-update-error-on-console/)
I have a strong feeling that this issue is only happening when something in the WordPress theme or site is misconfigured that's causing pages to pass our other conditions because I couldn't reproduce the issue on the test site and the issue is only being reported for a couple of sites.
If you look at one of the sites listed in the report thread, you can see that there's a `/wp-content/plugins/disqus-comment-system/public/js/comment_embed.js?ver=3.0.21` script on the page that shouldn't be added to pages that don't have comments. This is causing the rest of the plugin to think that we should go forward with adding the embed script, even though we don't have a `disqus_thread` element to load the thread into.

Someone with more WordPress knowledge could probably find a better solution.

## How Has This Been Tested?  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with the WP test site

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [x] All new and existing tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/disqus/disqus-wordpress-plugin/98)
<!-- Reviewable:end -->
