### PR TITLE
Check that host key exists before using in dsq_filter_rest_url

### DIFF
--- a/disqus/admin/class-disqus-admin.php
+++ b/disqus/admin/class-disqus-admin.php
@@ -168,7 +168,7 @@ class Disqus_Admin {
             $current_host = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : $rest_host;
 
             if ( $rest_host !== $current_host ) {
-                $rest_url = preg_replace( '/' . $rest_host . '/', $current_host, $rest_url, 1);
+                $rest_url = preg_replace( '/' . $rest_host . '/', $current_host, $rest_url, 1 );
             }
         }
 

--- a/disqus/admin/class-disqus-admin.php
+++ b/disqus/admin/class-disqus-admin.php
@@ -159,15 +159,17 @@ class Disqus_Admin {
      */
     public function dsq_filter_rest_url( $rest_url ) {
         $rest_url_parts = parse_url( $rest_url );
-        $rest_host = $rest_url_parts['host'];
-        if ( array_key_exists( 'port', $rest_url_parts ) ) {
-            $rest_host .= ':' . $rest_url_parts['port'];
-        }
+        if ( array_key_exists( 'host', $rest_url_parts ) ) {
+            $rest_host = $rest_url_parts['host'];
+            if ( array_key_exists( 'port', $rest_url_parts ) ) {
+                $rest_host .= ':' . $rest_url_parts['port'];
+            }
 
-        $current_host = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : $rest_host;
+            $current_host = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : $rest_host;
 
-        if ( $rest_host !== $current_host ) {
-            $rest_url = preg_replace( '/' . $rest_host . '/', $current_host, $rest_url, 1 );
+            if ( $rest_host !== $current_host ) {
+                $rest_url = preg_replace( '/' . $rest_host . '/', $current_host, $rest_url, 1);
+            }
         }
 
         return $rest_url;


### PR DESCRIPTION
## Description  
In environments where the `$rest_url` does not contain a host, like when running PHP scripts on the command line via Supervisord, php warns with a notice. To prevent these notices, this PR adds a check for the existence of 'host' before trying to use it in the `dsq_filter_rest_url` function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes issue #57, discussed more in https://github.com/disqus/disqus-wordpress-plugin/pull/60.

## How Has This Been Tested?  
1. Build the docker image using these instructions https://github.com/disqus/disqus-wordpress-plugin#local-testing
2. Run bash in the docker container with `docker exec -it disqus-wordpress-plugin_wordpress_1 /bin/bash`
3. Create a script file `my-script.php` with the following
```php
<?php
print("Hello!");
?>
```
4. Edit `wp-config.php` to remove the host:
```php
define('WP_HOME', 'https://' );
define('WP_SITEURL', 'https:///wordpress');
```
5. run a script to confirm the absence of the PHP notice `Undefined index: HTTP_HOST" for no web server` with `docker exec -it disqus-wordpress-plugin_wordpress_1 /bin/bash wp eval-file my-script.php`

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
