### PR TITLE
fix: Automatic Sync not adding comment post ID

### DIFF
--- a/disqus/rest-api/class-disqus-rest-api.php
+++ b/disqus/rest-api/class-disqus-rest-api.php
@@ -738,25 +738,23 @@ class Disqus_Rest_Api {
         ) );
 
         if ( $post_query->have_posts() ) {
-            $wp_post_id = $post_query->post->ID;
-            wp_reset_postdata();
+            $wp_post_id = $post_query->posts[0]->ID;
         }
 
         // If that doesn't exist, get the  and update the matching post metadata.
-        if ( null === $wp_post_id || false === $wp_post_id ) {
+        if ( empty($wp_post_id) ) {
             $identifiers = $thread['identifiers'];
             $first_identifier = count( $identifiers ) > 0 ? $identifiers[0] : null;
 
-            if ( null !== $first_identifier ) {
-                $ident_parts = explode( ' ', $first_identifier, 2 );
-                $wp_post_id = reset( $ident_parts );
+            if ( ! is_null( $first_identifier ) ) {
+                $wp_post_id = url_to_postid( $first_identifier );
             }
 
             // Keep the post's thread ID meta up to date.
             update_post_meta( $wp_post_id, 'dsq_thread_id', $thread['id'] );
         }
 
-        if ( null === $wp_post_id || false == $wp_post_id ) {
+        if ( empty( $wp_post_id ) ) {
             throw new Exception( 'No post found associated with the thread.' );
         }
 
@@ -779,7 +777,6 @@ class Disqus_Rest_Api {
 
         // Email is a special permission for Disqus API applications and won't be present
         // if the user has not set the permission for their API application.
-        $author_email = null;
         if ( isset( $author['email'] ) ) {
             $author_email = $author['email'];
         } elseif ( $author['isAnonymous'] ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description  
<!--- Describe your changes in detail -->
This PR fixes adding `comment_post_ID` when synchronizing comments.

https://github.com/disqus/disqus-wordpress-plugin/blob/c3b5e9253ff5b6738706698047add41f2f40a2d3/disqus/rest-api/class-disqus-rest-api.php#L751
I checked what ` $thread['identifiers']` returns and that code made no sense. That's why the synchronization wasn't working.

## Motivation and Context  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #41 

## How Has This Been Tested?  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I uploaded the code changes to production and finally the sync started working. After a year!

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have updated the documentation accordingly.   
- [ ] All new and existing tests passed.  
