### PR TITLE
Fix Manual Syncing Tool - 

### DIFF
--- a/disqus/rest-api/class-disqus-rest-api.php
+++ b/disqus/rest-api/class-disqus-rest-api.php
@@ -768,6 +768,8 @@ class Disqus_Rest_Api {
         }
 
         // Find the parent comment, if any.
+        // To simplify our syncing process and prevent syncing errors, 
+        // still sync the comment even if we don't have its parent comment synced. 
         $parent = 0;
         if ( null !== $post['parent'] ) {
             $parent_comment_query = new WP_Comment_Query( array(
@@ -777,9 +779,7 @@ class Disqus_Rest_Api {
             ) );
             $parent_comments = $parent_comment_query->comments;
 
-            if ( empty( $parent_comments ) ) {
-                throw new Exception( 'This comment\'s parent has not been synced yet.' );
-            } else {
+            if ( $parent_comments ) {
                 $parent = $parent_comments[0]->comment_ID;
             }
         }

--- a/disqus/rest-api/class-disqus-rest-api.php
+++ b/disqus/rest-api/class-disqus-rest-api.php
@@ -700,7 +700,6 @@ class Disqus_Rest_Api {
         // Remove non-updating fields.
         unset( $comment_data['comment_meta'] );
         unset( $comment_data['comment_agent'] );
-        unset( $comment_data['comment_parent'] );
         unset( $comment_data['comment_type'] );
         unset( $comment_data['comment_date_gmt'] );
         unset( $comment_data['comment_post_ID'] );

--- a/disqus/rest-api/class-disqus-rest-api.php
+++ b/disqus/rest-api/class-disqus-rest-api.php
@@ -768,8 +768,8 @@ class Disqus_Rest_Api {
         }
 
         // Find the parent comment, if any.
-        // To simplify our syncing process and prevent syncing errors, 
-        // still sync the comment even if we don't have its parent comment synced. 
+        // To simplify our syncing process and prevent syncing errors,
+        // still sync the comment even if we don't have its parent comment synced.
         $parent = 0;
         if ( null !== $post['parent'] ) {
             $parent_comment_query = new WP_Comment_Query( array(

--- a/disqus/rest-api/class-disqus-rest-api.php
+++ b/disqus/rest-api/class-disqus-rest-api.php
@@ -763,10 +763,6 @@ class Disqus_Rest_Api {
             update_post_meta( $wp_post_id, 'dsq_thread_id', $thread['id'] );
         }
 
-        if ( null === $wp_post_id || false == $wp_post_id ) {
-            throw new Exception( 'No post found associated with the thread.' );
-        }
-
         // Find the parent comment, if any.
         // To simplify our syncing process and prevent syncing errors,
         // still sync the comment even if we don't have its parent comment synced.

--- a/frontend/src/ts/DisqusApi.ts
+++ b/frontend/src/ts/DisqusApi.ts
@@ -54,6 +54,7 @@ export class DisqusApi {
             `end=${endDate.toISOString()}`,
             `forum=${this.forum}`,
             'related=thread',
+            'order=asc',
             `limit=${Math.min(Math.max(limit, 1), 100)}`,
             `cursor=${cursor || ''}`,
         ].join('&');

--- a/frontend/src/ts/DisqusApi.ts
+++ b/frontend/src/ts/DisqusApi.ts
@@ -62,14 +62,6 @@ export class DisqusApi {
         return this.get('posts/list', query, onLoad);
     }
 
-    public listPostDetails(
-        postID: number,
-        onLoad: EventListenerOrEventListenerObject,
-    ): XMLHttpRequest {
-        const query: string = `post=${postID}`
-        return this.get('posts/details', query, onLoad);
-    }
-
     private get(path: string, query: string, onLoad: EventListenerOrEventListenerObject): XMLHttpRequest {
         if (!this.apiKey)
             return null;

--- a/frontend/src/ts/DisqusApi.ts
+++ b/frontend/src/ts/DisqusApi.ts
@@ -62,6 +62,14 @@ export class DisqusApi {
         return this.get('posts/list', query, onLoad);
     }
 
+    public listPostDetails(
+        postID: number,
+        onLoad: EventListenerOrEventListenerObject,
+    ): XMLHttpRequest {
+        const query: string = `post=${postID}`
+        return this.get('posts/details', query, onLoad);
+    }
+
     private get(path: string, query: string, onLoad: EventListenerOrEventListenerObject): XMLHttpRequest {
         if (!this.apiKey)
             return null;

--- a/frontend/src/ts/WordPressRestApi.ts
+++ b/frontend/src/ts/WordPressRestApi.ts
@@ -121,7 +121,7 @@ export class WordPressRestApi {
                         status: XHR.status,
                         statusText: XHR.statusText
                     });
-                    console.error('Error', XHR.statusText);
+                    console.error('Error', XHR.statusText, 'error XHR --> ', XHR);
                 }
             };
             XHR.send(data);

--- a/frontend/src/ts/WordPressRestApi.ts
+++ b/frontend/src/ts/WordPressRestApi.ts
@@ -121,7 +121,7 @@ export class WordPressRestApi {
                         status: XHR.status,
                         statusText: XHR.statusText
                     });
-                    console.error('Error Status: ', XHR.statusText, 'Full Error XHR: ', XHR);
+                    console.error('Error Status: ', XHR.statusText, '100 character server response preview: ', XHR.responseText.substring(0, 100));
                 }
             };
             XHR.send(data);

--- a/frontend/src/ts/WordPressRestApi.ts
+++ b/frontend/src/ts/WordPressRestApi.ts
@@ -121,7 +121,7 @@ export class WordPressRestApi {
                         status: XHR.status,
                         statusText: XHR.statusText
                     });
-                    console.error('Error', XHR.statusText, 'error XHR --> ', XHR);
+                    console.error('Error Status: ', XHR.statusText, 'Full Error XHR: ', XHR);
                 }
             };
             XHR.send(data);

--- a/frontend/src/ts/components/ManualSyncForm.tsx
+++ b/frontend/src/ts/components/ManualSyncForm.tsx
@@ -11,7 +11,7 @@ const ManualSyncForm = (props: IFormProps) => {
         >
             <h4>{__('Manually Sync Comments')}</h4>
             <p className='description'>
-                {__('Select a time range to sync past comments. Date ranges are limited to a maximum of 12 months.')}
+                {__('Select a time range to sync past comments. Date ranges can go up to a maximum of 5 years.')}
             </p>
             <table className='form-table'>
                 <tbody>
@@ -30,7 +30,7 @@ const ManualSyncForm = (props: IFormProps) => {
                                 value={props.data.manualSyncRangeStart}
                                 onChange={props.onDateSelectorInputchange.bind(null, 'manualSyncRangeStart')}
                                 max={props.data.manualSyncRangeEnd}
-                                min={moment(props.data.manualSyncRangeEnd).subtract(12, 'months').format('YYYY-MM-DD')}
+                                min={moment(props.data.manualSyncRangeEnd).subtract(60, 'months').format('YYYY-MM-DD')}
                                 disabled={props.data.isManualSyncRunning}
                             />
                             <p className='description'>

--- a/frontend/src/ts/containers/mapDispatchToProps.ts
+++ b/frontend/src/ts/containers/mapDispatchToProps.ts
@@ -50,11 +50,11 @@ let syncedComments = 0;
 let totalSyncedComments = 0;
 
 const syncComments = async (commentQueue: any[], dispatch: Redux.Dispatch<Redux.Action>, commentType: String) => {
-    const parallelRequests: Promise <void> [] = [];
     // We need to throttle the amount of parallel sync requests that we make
     // because large forums could be syncing thousands of comments
     // Parent comments can be synced in parallel but child comments need to be synced 1 at a time
     const maxParallelRequests = commentType === 'parentComments' ? 100 : 1;
+    const parallelRequests: Promise <void> [] = [];
     for (let comment of commentQueue) {
         // Make the sync request and add its promise to the queue,
         // and remove it from queue when complete

--- a/frontend/src/ts/containers/mapDispatchToProps.ts
+++ b/frontend/src/ts/containers/mapDispatchToProps.ts
@@ -52,8 +52,7 @@ let totalSyncedComments = 0;
 const syncComments = async (commentQueue: any[], dispatch: Redux.Dispatch<Redux.Action>, commentType: String) => {
     // We need to throttle the amount of parallel sync requests that we make
     // because large forums could be syncing thousands of comments
-    // Parent comments can be synced in parallel but child comments need to be synced 1 at a time
-    const maxParallelRequests = commentType === 'parentComments' ? 100 : 1;
+    const maxParallelRequests = 100;
     const parallelRequests: Promise <void> [] = [];
     for (let comment of commentQueue) {
         // Make the sync request and add its promise to the queue,

--- a/frontend/src/ts/containers/mapDispatchToProps.ts
+++ b/frontend/src/ts/containers/mapDispatchToProps.ts
@@ -99,36 +99,6 @@ const syncComments = async (commentQueue: any[], dispatch: Redux.Dispatch<Redux.
     });
 }
 
-// takes in a queue and its parent ID and returns a queue of comments from parent to child
-const fetchAllParentComments = async (queue: any[], parentCommentID: number, threadData: any) => {
-    // find parent comment
-    const parentComment: any = await fetchPostDetails(parentCommentID);
-    // assign the thread data to the fetched comment
-    parentComment.thread = threadData;
-    // add parent comment to the front of the queue
-    queue.unshift(parentComment);
-    // if the parent comment has a parent, run the function again with the new parent comment
-    if (parentComment.parent) {
-        fetchAllParentComments(queue, parentComment.parent, threadData);
-    } else {
-        return queue;
-    }
-}
-
-const fetchPostDetails = async (postID: number) => {
-    return new Promise((resolve, reject) => {
-        DisqusApi.instance.listPostDetails(postID, async (xhr: Event) => {
-            let disqusData = null;
-            try {
-                disqusData = JSON.parse((xhr.target as XMLHttpRequest).responseText);
-            } catch (error) {
-                console.error(`Could not fetch post details for postID ${postID}.  Error: ${error}`)
-            }
-            resolve(disqusData.response);
-        });
-    });
-}
-
 const mapDispatchToProps = (dispatch: Redux.Dispatch<Redux.Action>) => {
     const handleClearMessage = (event: React.SyntheticEvent<HTMLButtonElement>): void => {
         dispatch(setMessageAction(null));
@@ -186,7 +156,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<Redux.Action>) => {
 
             // Create a queue of comments within the provided date-range from the Disqus API
             const parentCommentList: any[] = [];
-            const commentDict: any = {};
+            const childCommentList: any[] = [];
             const getDisqusComments = async (cursor: string = '') => {
                 return new Promise((resolve, reject) => {
                     DisqusApi.instance.listPostsForForum(cursor, startDate, endDate, 100, async (xhr: Event) => {
@@ -206,59 +176,23 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<Redux.Action>) => {
                                 last_message: null,
                             }));
                         }
-                        const nextCursor = disqusData.cursor;
-                        if (nextCursor && nextCursor.hasNext) {
-                            await getDisqusComments(nextCursor.next);
-                        }
-
+                        
                         const pendingComments = disqusData.response;
-                        totalSyncedComments = pendingComments.length;
+                        totalSyncedComments += pendingComments.length;
 
-                        // Build a dictionary of comments and a list of parentComments
                         pendingComments.forEach((comment: any) => {
-                            commentDict[comment.id] = comment;
-                            if (!comment.parent) {
+                            if (comment.parent) {
+                                childCommentList.push(comment);
+                            } else {
                                 parentCommentList.push(comment);
                             }
                         });
 
-                        totalSyncedComments = parentCommentList.length;
-                    
-                        // check each childComment to make sure we have the necessary parents to prevent API errors
-                        const buildChildCommentList = async () => {
-                            const childCommentList: any[] = [];
-                            const fetchPromises: any[] = [];
-                            for (const comment of pendingComments) {
-                                let currentComment = comment;
-                                if (currentComment.parent) {
-                                    // if we have the current comment's parent, just add it to the list
-                                    if (commentDict[currentComment.parent]) {
-                                        childCommentList.push(currentComment);
-                                    } else {
-                                        // if we don't have its parent, fetch it and all of its parents
-                                        const queue = await fetchAllParentComments([currentComment], currentComment.parent, currentComment.thread);
-                                        // add the comments to the list
-                                        if (queue) {
-                                            for (const [index, comment] of queue.entries()) {
-                                                if (index === 0) {
-                                                    parentCommentList.push(comment);   
-                                                } else {
-                                                    childCommentList.push(comment);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                fetchPromises.push(Promise.resolve());
-                            };
-                            await Promise.all(fetchPromises);
-                            return childCommentList;
-                        };
-                        buildChildCommentList().then((childCommentList) => {
-                            const commentQueue = [parentCommentList, childCommentList];
-                            totalSyncedComments = parentCommentList.length + childCommentList.length;
-                            resolve(commentQueue);
-                        });
+                        const nextCursor = disqusData.cursor;
+                        if (nextCursor && nextCursor.hasNext) {
+                            await getDisqusComments(nextCursor.next);
+                        }
+                        resolve([parentCommentList, childCommentList]);
                     });
                 });
             };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description  
<!--- Describe your changes in detail -->
Sometimes, the manual syncing tool would only sync some comments and not others, and the only indication that there was something wrong would be a 500 error.  After some digging, it was determined that this was happening when the syncing tool would attempt to sync a child comment before that child's parent comment was synced.  

To fix this, we switched the order that we fetch comments from the Disqus API, and we sync parent comments before child comments in order to do our best effort to sync child comments in the right order.  To account for child comments with parents outside of the date range that haven't been synced yet, we removed the check for parent comments to allow those child comments to still sync.  Later on, if those parent comments get synced, we made a change so that these child comments will update with the parent comment data.

A second issue that was discovered in testing was that comments posted via RSS would have trouble syncing due to missing an identifier in the thread data.  This was remedied by removing the error when missing the thread data, which would still allow for syncing of these comments minus a direct link to the comment in the WordPress UI that would otherwise be there in non-RSS comment.

Additionally, these changes include improvements to the logging that we expose in the browser console to make future troubleshooting easier.

And last but not least, per the request of some users, we increased the date range for manual syncing to 5 years to make the tool easier to use for bulk comment syncing.

## Motivation and Context  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This bug was reported by a few publishers to the Disqus support team and would consistently break the syncing tool.

## How Has This Been Tested?  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested on the Disqus WP test site hooked up to the Disqus Blog.  Aside from testing the actual syncing, we benchmarked the syncing with staggered parallelism vs without staggered parallelism, and we decided to remove staggered parallelism since the results were about twice as fast with syncing.

- Parameters: 6 months: 6/1/22 - 1/1/23. 2089 comments
- With staggered parallelism: 13 min 38 seconds.  All comments synced.
- Without staggered parallelism: 7 min 55 seconds.  All comments synced.

Tests for increasing the date range: Was curious as to how the tool would perform without limiting to 1 year, so did additional tests with larger sizes (only without staggered parallelism so it wouldn't take too long):

- Parameters: 3 years (1/1/21 - 12/12/23).  4123 comments
- Without staggered parallelism: 15min 45 seconds.  All comments synced.

- Parameters: 5 years (12/12/18 - 12/12/23). 12730 comments
- Without staggered parallelism: 49 minutes.  All comments synced.

## Screenshots (if appropriate):  

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have updated the documentation accordingly.   
- [x] All new and existing tests passed.  