### PR TITLE
Configure DISQUS to load on WordPress Block Themes via Plugin

### DIFF
--- a/disqus/includes/class-disqus.php
+++ b/disqus/includes/class-disqus.php
@@ -180,6 +180,7 @@ class Disqus {
         $this->loader->add_filter( 'comments_number', $plugin_public, 'dsq_comments_link_template' );
         $this->loader->add_filter( 'comments_template', $plugin_public, 'dsq_comments_template' );
         $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_comment_count' );
+        $this->loader->add_action( 'comment_form_before', $plugin_public, 'hide_block_theme_comment_section');
         $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_comment_embed' );
         $this->loader->add_action( 'show_user_profile', $plugin_public, 'dsq_close_window_template' );
     }

--- a/disqus/includes/class-disqus.php
+++ b/disqus/includes/class-disqus.php
@@ -180,7 +180,7 @@ class Disqus {
         $this->loader->add_filter( 'comments_number', $plugin_public, 'dsq_comments_link_template' );
         $this->loader->add_filter( 'comments_template', $plugin_public, 'dsq_comments_template' );
         $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_comment_count' );
-        $this->loader->add_action( 'comment_form_before', $plugin_public, 'hide_block_theme_comment_section');
+        $this->loader->add_action( 'comment_form_before', $plugin_public, 'hide_block_theme_comment_section' );
         $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_comment_embed' );
         $this->loader->add_action( 'show_user_profile', $plugin_public, 'dsq_close_window_template' );
     }

--- a/disqus/public/class-disqus-public.php
+++ b/disqus/public/class-disqus-public.php
@@ -238,6 +238,22 @@ class Disqus_Public {
 		}
 	}
 
+    /**
+	 * Hides the comment section block for WP block themes.
+     * This prevents the WP block comment section from appearing briefly before being replaced by Disqus.
+	 *
+	 * @since    3.0
+	 */
+	public function hide_block_theme_comment_section() {
+		?>
+            <style>
+                .wp-block-comments {
+                    display: none;
+                }
+            </style>
+        <?php
+	}
+
 	/**
 	 * Determines if Disqus is configured and can load on a given page.
 	 *

--- a/disqus/public/js/comment_embed.js
+++ b/disqus/public/js/comment_embed.js
@@ -23,11 +23,18 @@ var disqus_config = function () {
 };
 
 (function() {
+    // Adds the disqus_thread id to the comment section if site is using a WP block theme
+    var commentsBlock = document.querySelector('.wp-block-comments');
+    if (commentsBlock) {
+        commentsBlock.id = 'disqus_thread';
+    }
     if (document.getElementById(disqus_container_id)) {
         var dsq = document.createElement('script');
         dsq.type = 'text/javascript';
         dsq.async = true;
         dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    } else {
+        console.error("Could not find 'disqus_thread' container to load DISQUS.  This is usually the result of a WordPress theme conflicting with the DISQUS plugin.  Try switching your site to a Classic Theme, or contact DISQUS support for help.");
     }
 })();


### PR DESCRIPTION
## Description  

- Add `disqus_thread` id to comment section for block themes to allow for loading the Embed.
- Add console_error message if the `disqus_thread` container is not on the page.
- Add function to hide the block theme comment section before initial render to prevent it from appearing briefly before DISQUS loads.

## Motivation and Context  
WordPress Block Themes were released in 2022, but the DISQUS plugin hadn't been updated to load on these themes.  This is an issue in general, but specifically because the newest default themes that WordPress comes with are Block Themes.

https://github.com/disqus/disqus-wordpress-plugin/issues/132

## How Has This Been Tested?  
Confirmed on test site that DISQUS now loads on latest WordPress Themes: Twenty Twenty-Two, Twenty Twenty-Three, and Twenty Twenty-Four.  

## Screenshots (if appropriate):  

![Screen Shot 2024-02-15 at 3 55 38 PM](https://github.com/disqus/disqus-wordpress-plugin/assets/82986336/d152358e-2a4f-41c4-91d1-27dc707d5cc9)
![Screen Shot 2024-02-15 at 3 55 25 PM](https://github.com/disqus/disqus-wordpress-plugin/assets/82986336/463d054c-5be2-4fb9-a616-1063491bad35)
![Screen Shot 2024-02-15 at 3 55 09 PM](https://github.com/disqus/disqus-wordpress-plugin/assets/82986336/014ce8ad-6f0c-4a82-8090-44133348a263)

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [x] My change requires a change to the documentation.  
  - [x] I have updated the documentation accordingly.   
- [x] All new and existing tests passed.  
