### PR TITLE
Explicitly globalize $DISQUSVERSION variable

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -24,7 +24,7 @@
  * Domain Path:       /languages
  */
 
-$DISQUSVERSION = '3.1.2';
+$GLOBALS['DISQUSVERSION'] = '3.1.2';
 
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {


### PR DESCRIPTION
## Description

Explicitly assigns `DISQUSVERSION` to `$GLOBALS` rather than relying on the plugin file being loaded in global scope.

## Motivation and Context

By default, WordPress core loads active plugins in global scope. However, at our agency, we typically load plugins in code, which allows for more consistency across environments and less risk of accidental deactivation by users. See our [plugin loader library](https://github.com/alleyinteractive/wp-plugin-loader) and also [the recommendation from WordPress VIP for sites on their platform](https://docs.wpvip.com/plugins/activate-plugins-through-code/).

In these scenarios, plugins are typically not loaded within global scope, and so variables defined in the plugin entry file are not automatically globalized.

Although [workarounds exist to globalize variables manually](https://github.com/Automattic/vip-go-mu-plugins/blob/50d93d896c78dade1212f90f868d82299b900d65/vip-helpers/vip-utils.php#L1381-L1424) after including the plugin entry file, the Disqus plugin poses a challenge because it relies on the `DISQUSVERSION` variable, as a `global`, later in the same entry file, here: https://github.com/disqus/disqus-wordpress-plugin/blob/9c20fe3a8e5577b2e7ee3094b0c6a8d1af15859a/disqus/disqus.php#L62-L78

When the plugin is loaded in code, that variable does not exist yet as a global when `run_disqus()` runs.

The fix proposed here is to just assign `DISQUSVERSION` directly to `$GLOBALS`, rather than the current approach of assuming that the plugin is being loaded in such a way that the variable will end up in `$GLOBALS`. This change should ensure the variable is available to `run_disqus()` even when the Disqus plugin is loaded in code. 

## How Has This Been Tested?

Use the [Plugin Loader](https://github.com/alleyinteractive/wp-plugin-loader) library to attempt to load the Disqus plugin:

```
new \Alley\WP\WP_Plugin_Loader( [ 'disqus-comment-system/disqus.php' ] );
```

Observe that the Disqus settings page fails to load because the version number is missing from the enqueued JavaScript.

Apply the change, and observe that the version number is present again.

## Types of changes  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
- [x] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have updated the documentation accordingly.   
- [ ] All new and existing tests passed.  
