### PR TITLE
Fix SSO Avatars

### DIFF
--- a/disqus/public/class-disqus-public.php
+++ b/disqus/public/class-disqus-public.php
@@ -374,7 +374,7 @@ class Disqus_Public {
 	private static function ensure_gravatar_extension( $avatar_url, $ext = '.jpg' ) {
 		if ( strpos( $avatar_url, 'gravatar.com' ) !== false ) {
 			$query_pos = strpos( $avatar_url, '?' );
-			if ( $query_pos !== false ) {
+			if ( false !== $query_pos ) {
 				return substr( $avatar_url, 0, $query_pos ) . $ext . substr( $avatar_url, $query_pos );
 			} else {
 				return $avatar_url . $ext;

--- a/disqus/public/class-disqus-public.php
+++ b/disqus/public/class-disqus-public.php
@@ -56,9 +56,10 @@ class Disqus_Public {
 	public static function remote_auth_s3_for_user( $user, $secret_key ) {
 		$payload_user = array();
 		if ( $user->ID ) {
-			$payload_user['id'] = $user->ID;
-			$payload_user['username'] = $user->display_name;
-			$payload_user['avatar'] = get_avatar_url( $user->ID, 92 );
+            $avatar_url = self::ensure_gravatar_extension( get_avatar_url( $user->ID, 92 ) );
+            $payload_user['id'] = $user->ID;
+            $payload_user['username'] = $user->display_name;
+            $payload_user['avatar'] = $avatar_url;
 			$payload_user['email'] = $user->user_email;
 			$payload_user['url'] = $user->user_url;
 		}
@@ -108,7 +109,6 @@ class Disqus_Public {
 			$embed_vars['disqusConfig']['api_key'] = $public_key;
 			$embed_vars['disqusConfig']['remote_auth_s3'] = Disqus_Public::remote_auth_s3_for_user( $user, $secret_key );
 		}
-
 		return $embed_vars;
 	}
 
@@ -359,4 +359,27 @@ class Disqus_Public {
 
 		return true;
 	}
+
+    /**
+	 * By default, WP uses Gravatar for its avatars without an image extension, but our SSO payload expects an extension,
+     * so this function ensures a Gravatar URL ends with .jpg before query params and leaves other URLs unchanged.
+     * Source: https://docs.gravatar.com/sdk/images/
+	 *
+	 * @since     3.1.3
+	 * @access    private
+	 * @param     string $avatar_url     The avatar URL to check.
+     * @param     string $ext            The extension to append, default is '.jpg'.
+	 * @return    string                 The modified avatar URL with the correct extension.
+	 */
+    private static function ensure_gravatar_extension( $avatar_url, $ext = '.jpg' ) {
+        if ( strpos( $avatar_url, 'gravatar.com' ) !== false ) {
+            $query_pos = strpos( $avatar_url, '?' );
+            if ($query_pos !== false) {
+                return substr( $avatar_url, 0, $query_pos ) . $ext . substr( $avatar_url, $query_pos );
+            } else {
+                return $avatar_url . $ext;
+            }
+        }
+        return $avatar_url;
+    }
 }

--- a/disqus/public/class-disqus-public.php
+++ b/disqus/public/class-disqus-public.php
@@ -372,8 +372,17 @@ class Disqus_Public {
 	 * @return    string                 The modified avatar URL with the correct extension.
 	 */
 	private static function ensure_gravatar_extension( $avatar_url, $ext = '.jpg' ) {
-		if ( strpos( $avatar_url, 'gravatar.com' ) !== false ) {
-			$query_pos = strpos( $avatar_url, '?' );
+		if ( $ext[0] !== '.' ) {
+			$ext = '.' . $ext;
+		}
+
+		$query_pos = strpos( $avatar_url, '?' );
+		$base = ( false !== $query_pos ) ? substr( $avatar_url, 0, $query_pos ) : $avatar_url;
+		if ( substr( $base, -strlen( $ext ) ) === $ext ) {
+			return $avatar_url;
+		}
+
+		if ( false !== stripos( $avatar_url, 'gravatar.com' ) ) {
 			if ( false !== $query_pos ) {
 				return substr( $avatar_url, 0, $query_pos ) . $ext . substr( $avatar_url, $query_pos );
 			} else {

--- a/disqus/public/class-disqus-public.php
+++ b/disqus/public/class-disqus-public.php
@@ -56,10 +56,10 @@ class Disqus_Public {
 	public static function remote_auth_s3_for_user( $user, $secret_key ) {
 		$payload_user = array();
 		if ( $user->ID ) {
-            $avatar_url = self::ensure_gravatar_extension( get_avatar_url( $user->ID, 92 ) );
-            $payload_user['id'] = $user->ID;
-            $payload_user['username'] = $user->display_name;
-            $payload_user['avatar'] = $avatar_url;
+			$avatar_url = self::ensure_gravatar_extension( get_avatar_url( $user->ID, 92 ) );
+			$payload_user['id'] = $user->ID;
+			$payload_user['username'] = $user->display_name;
+			$payload_user['avatar'] = $avatar_url;
 			$payload_user['email'] = $user->user_email;
 			$payload_user['url'] = $user->user_url;
 		}
@@ -360,26 +360,26 @@ class Disqus_Public {
 		return true;
 	}
 
-    /**
+	/**
 	 * By default, WP uses Gravatar for its avatars without an image extension, but our SSO payload expects an extension,
-     * so this function ensures a Gravatar URL ends with .jpg before query params and leaves other URLs unchanged.
-     * Source: https://docs.gravatar.com/sdk/images/
+	 * so this function ensures a Gravatar URL ends with .jpg before query params and leaves other URLs unchanged.
+	 * Source: https://docs.gravatar.com/sdk/images/
 	 *
 	 * @since     3.1.3
 	 * @access    private
 	 * @param     string $avatar_url     The avatar URL to check.
-     * @param     string $ext            The extension to append, default is '.jpg'.
+	 * @param     string $ext            The extension to append, default is '.jpg'.
 	 * @return    string                 The modified avatar URL with the correct extension.
 	 */
-    private static function ensure_gravatar_extension( $avatar_url, $ext = '.jpg' ) {
-        if ( strpos( $avatar_url, 'gravatar.com' ) !== false ) {
-            $query_pos = strpos( $avatar_url, '?' );
-            if ($query_pos !== false) {
-                return substr( $avatar_url, 0, $query_pos ) . $ext . substr( $avatar_url, $query_pos );
-            } else {
-                return $avatar_url . $ext;
-            }
-        }
-        return $avatar_url;
-    }
+	private static function ensure_gravatar_extension( $avatar_url, $ext = '.jpg' ) {
+		if ( strpos( $avatar_url, 'gravatar.com' ) !== false ) {
+			$query_pos = strpos( $avatar_url, '?' );
+			if ( $query_pos !== false ) {
+				return substr( $avatar_url, 0, $query_pos ) . $ext . substr( $avatar_url, $query_pos );
+			} else {
+				return $avatar_url . $ext;
+			}
+		}
+		return $avatar_url;
+	}
 }

--- a/disqus/public/class-disqus-public.php
+++ b/disqus/public/class-disqus-public.php
@@ -372,7 +372,7 @@ class Disqus_Public {
 	 * @return    string                 The modified avatar URL with the correct extension.
 	 */
 	private static function ensure_gravatar_extension( $avatar_url, $ext = '.jpg' ) {
-		if ( $ext[0] !== '.' ) {
+		if ( '.' !== $ext[0] ) {
 			$ext = '.' . $ext;
 		}
 

--- a/tests/test-public.php
+++ b/tests/test-public.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Tests for Disqus_Public class.
+ */
+
+class Test_Disqus_Public extends WP_UnitTestCase {
+
+    /**
+     * Test ensure_gravatar_extension with Gravatar URLs.
+     */
+    function test_ensure_gravatar_extension_with_gravatar_urls() {
+        $reflection = new ReflectionClass('Disqus_Public');
+        $method = $reflection->getMethod('ensure_gravatar_extension');
+        $method->setAccessible(true);
+
+        // Test Gravatar URL without extension
+        $url = 'https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50';
+        $result = $method->invoke(null, $url);
+        $this->assertEquals('https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50.jpg', $result);
+
+        // Test Gravatar URL with query params
+        $url = 'https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=92';
+        $result = $method->invoke(null, $url);
+        $this->assertEquals('https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50.jpg?s=92', $result);
+
+        // Test Gravatar URL already with extension
+        $url = 'https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50.jpg';
+        $result = $method->invoke(null, $url);
+        $this->assertEquals('https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50.jpg', $result);
+
+        // Test Gravatar URL with extension and query params
+        $url = 'https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50.jpg?s=92';
+        $result = $method->invoke(null, $url);
+        $this->assertEquals('https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50.jpg?s=92', $result);
+
+        // Test secure Gravatar URL
+        $url = 'https://secure.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50';
+        $result = $method->invoke(null, $url);
+        $this->assertEquals('https://secure.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50.jpg', $result);
+    }
+
+    /**
+     * Test ensure_gravatar_extension with non-Gravatar URLs.
+     */
+    function test_ensure_gravatar_extension_with_non_gravatar_urls() {
+        $reflection = new ReflectionClass('Disqus_Public');
+        $method = $reflection->getMethod('ensure_gravatar_extension');
+        $method->setAccessible(true);
+
+        // Test non-Gravatar URL (should remain unchanged)
+        $url = 'https://example.com/avatar.png';
+        $result = $method->invoke(null, $url);
+        $this->assertEquals('https://example.com/avatar.png', $result);
+
+        // Test non-Gravatar URL without extension
+        $url = 'https://example.com/avatar';
+        $result = $method->invoke(null, $url);
+        $this->assertEquals('https://example.com/avatar', $result);
+    }
+
+    /**
+     * Test ensure_gravatar_extension with custom extension.
+     */
+    function test_ensure_gravatar_extension_with_custom_extension() {
+        $reflection = new ReflectionClass('Disqus_Public');
+        $method = $reflection->getMethod('ensure_gravatar_extension');
+        $method->setAccessible(true);
+
+        // Test with custom extension
+        $url = 'https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50';
+        $result = $method->invoke(null, $url, '.png');
+        $this->assertEquals('https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50.png', $result);
+
+        // Test with custom extension without dot
+        $result = $method->invoke(null, $url, 'png');
+        $this->assertEquals('https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50.png', $result);
+    }
+
+    /**
+     * Test ensure_gravatar_extension edge cases.
+     */
+    function test_ensure_gravatar_extension_edge_cases() {
+        $reflection = new ReflectionClass('Disqus_Public');
+        $method = $reflection->getMethod('ensure_gravatar_extension');
+        $method->setAccessible(true);
+
+        // Test empty URL
+        $result = $method->invoke(null, '');
+        $this->assertEquals('', $result);
+
+        // Test URL with multiple query params
+        $url = 'https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=92&d=identicon';
+        $result = $method->invoke(null, $url);
+        $this->assertEquals('https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50.jpg?s=92&d=identicon', $result);
+
+        // Test URL with different case
+        $url = 'https://www.GRAVATAR.com/avatar/205e460b479e2e5b48aec07710c08d50';
+        $result = $method->invoke(null, $url);
+        $this->assertEquals('https://www.GRAVATAR.com/avatar/205e460b479e2e5b48aec07710c08d50.jpg', $result);
+    }
+}


### PR DESCRIPTION
## Description  
Publishers using SSO configured through the Disqus WP plugin are having issues with custom avatars showing up because WordPress uses Gravatar to manage default avatars, and the Gravatar image URLs are being provided in a format that is different from what the Disqus plugin was expecting.

## Motivation and Context  
https://zetaglobal.atlassian.net/browse/DSQDEV-4118

## How Has This Been Tested?  
This has been tested on the Disqus WP Developer instance.

## Screenshots (if appropriate):  

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have updated the documentation accordingly.   
- [x] All new and existing tests passed.  
