### PR TITLE
Switch DISQUSVERSION to constant

### DIFF
--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -113,7 +113,9 @@ bump disqus/README.txt "Stable tag: $current_version" "Stable tag: $new_version"
 
 # Update disqus.php versions
 bump disqus/disqus.php "Version:           $current_version" "Version:           $new_version"
-bump disqus/disqus.php "$DISQUSVERSION = '$current_version'" "$DISQUSVERSION = '$new_version'"
+bump disqus/disqus.php \
+     "define( 'DISQUS_VERSION', '$current_version' );" \
+     "define( 'DISQUS_VERSION', '$new_version' );"
 
 # Create commit with version updates
 echo "Committing version changes: \"Update plugin version to v$new_version\""

--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -24,12 +24,12 @@
  * Domain Path:       /languages
  */
 
-$DISQUSVERSION = '3.1.2';
-
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
 	die;
 }
+
+define( 'DISQUS_VERSION', '3.1.2' );
 
 /**
  * The code that runs during plugin activation (but not during updates).
@@ -69,9 +69,7 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-disqus.php';
  * @since    3.0
  */
 function run_disqus() {
-	global $DISQUSVERSION;
-
-	$plugin = new Disqus( $DISQUSVERSION );
+	$plugin = new Disqus( DISQUS_VERSION );
 	$plugin->run();
 
 }

--- a/disqus/public/class-disqus-public.php
+++ b/disqus/public/class-disqus-public.php
@@ -78,11 +78,9 @@ class Disqus_Public {
 	 * @return    array            The embed configuration to localize the comments embed script with.
 	 */
 	public static function embed_vars_for_post( $post ) {
-		global $DISQUSVERSION;
-
 		$embed_vars = array(
 			'disqusConfig' => array(
-				'integration' => 'wordpress ' . $DISQUSVERSION,
+				'integration' => 'wordpress ' . DISQUS_VERSION . ' ' . get_bloginfo( 'version' ),
 			),
 			'disqusIdentifier' => Disqus_Public::dsq_identifier_for_post( $post ),
 			'disqusShortname' => get_option( 'disqus_forum_url' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description  
The change switches from using a global variable `$DISQUSVERSION` to using a PHP constant `DISQUS_VERSION`.

## Motivation and Context  
Fixes #139 

## How Has This Been Tested?  
Manually verified that version is still being populated and sent in query string parameters.

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have updated the documentation accordingly.   
- [ ] All new and existing tests passed.  
