### PR TITLE
Fix Error when Author is Null

### DIFF
--- a/disqus/rest-api/class-disqus-rest-api.php
+++ b/disqus/rest-api/class-disqus-rest-api.php
@@ -791,7 +791,7 @@ class Disqus_Rest_Api {
 				$author_email = 'user-' . $author['id'] . '@disqus.com';
 			}
 		} else {
-            $author_email = 'anonymoususer@disqus.com';
+            $author_email = md5( 'no_author_data' ) . '@disqus.com';
         }
 
         // Translate the comment approval state.

--- a/disqus/rest-api/class-disqus-rest-api.php
+++ b/disqus/rest-api/class-disqus-rest-api.php
@@ -790,8 +790,6 @@ class Disqus_Rest_Api {
             } elseif ( isset( $author['id'] ) ) {
                 $author_email = 'user-' . $author['id'] . '@disqus.com';
             }
-        } else {
-            $author_email = md5( 'no_author_data' ) . '@disqus.com';
         }
 
         // Translate the comment approval state.

--- a/disqus/rest-api/class-disqus-rest-api.php
+++ b/disqus/rest-api/class-disqus-rest-api.php
@@ -732,7 +732,7 @@ class Disqus_Rest_Api {
      */
     private function comment_data_from_post( $post ) {
         $thread = array_key_exists( 'threadData', $post ) ? $post['threadData'] : $post['thread'];
-        $author = $post['author'];
+        $author = isset( $post['author'] ) ? $post['author'] : null;
 
         $wp_post_id = null;
 
@@ -782,12 +782,16 @@ class Disqus_Rest_Api {
         // Email is a special permission for Disqus API applications and won't be present
         // if the user has not set the permission for their API application.
         $author_email = null;
-        if ( isset( $author['email'] ) ) {
-            $author_email = $author['email'];
-        } elseif ( $author['isAnonymous'] ) {
-            $author_email = 'anonymized-' . md5( $author['name'] ) . '@disqus.com';
-        } else {
-            $author_email = 'user-' . $author['id'] . '@disqus.com';
+        if ( $author ) {
+			if ( isset( $author['email'] ) ) {
+				$author_email = $author['email'];
+			} elseif ( isset( $author['isAnonymous'] ) && $author['isAnonymous'] ) {
+				$author_email = 'anonymized-' . md5( $author['name'] ) . '@disqus.com';
+			} elseif ( isset( $author['id'] ) ) {
+				$author_email = 'user-' . $author['id'] . '@disqus.com';
+			}
+		} else {
+            $author_email = 'anonymoususer@disqus.com';
         }
 
         // Translate the comment approval state.
@@ -804,10 +808,10 @@ class Disqus_Rest_Api {
 
         return array(
             'comment_post_ID' => (int) $wp_post_id,
-            'comment_author' => $author['name'],
+            'comment_author' => $author && isset( $author['name'] ) ? $author['name'] : 'Anonymous',
             'comment_author_email' => $author_email,
             'comment_author_IP' => $post['ipAddress'],
-            'comment_author_url' => isset( $author['url'] ) ? $author['url'] : '',
+            'comment_author_url' => $author && isset( $author['url'] ) ? $author['url'] : '',
             'comment_content' => $post['raw_message'],
             'comment_date' => $post['createdAt'],
             'comment_date_gmt' => $post['createdAt'],

--- a/disqus/rest-api/class-disqus-rest-api.php
+++ b/disqus/rest-api/class-disqus-rest-api.php
@@ -783,14 +783,14 @@ class Disqus_Rest_Api {
         // if the user has not set the permission for their API application.
         $author_email = null;
         if ( $author ) {
-			if ( isset( $author['email'] ) ) {
-				$author_email = $author['email'];
-			} elseif ( isset( $author['isAnonymous'] ) && $author['isAnonymous'] ) {
-				$author_email = 'anonymized-' . md5( $author['name'] ) . '@disqus.com';
-			} elseif ( isset( $author['id'] ) ) {
-				$author_email = 'user-' . $author['id'] . '@disqus.com';
-			}
-		} else {
+            if ( isset( $author['email'] ) ) {
+                $author_email = $author['email'];
+            } elseif ( isset( $author['isAnonymous'] ) && $author['isAnonymous'] ) {
+                $author_email = 'anonymized-' . md5( $author['name'] ) . '@disqus.com';
+            } elseif ( isset( $author['id'] ) ) {
+                $author_email = 'user-' . $author['id'] . '@disqus.com';
+            }
+        } else {
             $author_email = md5( 'no_author_data' ) . '@disqus.com';
         }
 

--- a/tests/test-rest-api-comment-data-from-post.php
+++ b/tests/test-rest-api-comment-data-from-post.php
@@ -88,7 +88,6 @@ class Test_Disqus_Rest_Api_Comment_Data_From_Post extends WP_UnitTestCase {
             'forum' => get_option( 'disqus_forum_url' ),
         ];
         $data = $this->call_comment_data_from_post( $post );
-        $this->assertStringEndsWith( '@disqus.com', $data['comment_author_email'] );
-        $this->assertNotEmpty( $data['comment_author_email'] );
+        $this->assertNull( $data['comment_author_email'] );
     }
 }

--- a/tests/test-rest-api-comment-data-from-post.php
+++ b/tests/test-rest-api-comment-data-from-post.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ * Tests for Disqus_Rest_Api::comment_data_from_post author email logic.
+ */
+
+class Test_Disqus_Rest_Api_Comment_Data_From_Post extends WP_UnitTestCase {
+    protected $disqus_rest_api;
+
+    public function set_up() {
+        parent::set_up();
+        $this->disqus_rest_api = new Disqus_Rest_Api( null, null );
+    }
+
+    private function call_comment_data_from_post( $post ) {
+        $class = new ReflectionClass( 'Disqus_Rest_Api' );
+        $method = $class->getMethod( 'comment_data_from_post' );
+        $method->setAccessible( true );
+        return $method->invokeArgs( $this->disqus_rest_api, array( $post ) );
+    }
+
+    public function test_email_from_author_email() {
+        $post = [
+            'thread' => [ 'id' => 1, 'identifiers' => [ '1' ] ],
+            'author' => [ 'email' => 'foo@example.com', 'name' => 'Foo' ],
+            'parent' => null,
+            'ipAddress' => '127.0.0.1',
+            'raw_message' => 'Test',
+            'createdAt' => '2020-01-01 00:00:00',
+            'isApproved' => true,
+            'isDeleted' => false,
+            'isSpam' => false,
+            'id' => 123,
+            'forum' => get_option( 'disqus_forum_url' ),
+        ];
+        $data = $this->call_comment_data_from_post( $post );
+        $this->assertEquals( 'foo@example.com', $data['comment_author_email'] );
+    }
+
+    public function test_email_from_anonymous_author() {
+        $post = [
+            'thread' => [ 'id' => 1, 'identifiers' => [ '1' ] ],
+            'author' => [ 'isAnonymous' => true, 'name' => 'Anon' ],
+            'parent' => null,
+            'ipAddress' => '127.0.0.1',
+            'raw_message' => 'Test',
+            'createdAt' => '2020-01-01 00:00:00',
+            'isApproved' => true,
+            'isDeleted' => false,
+            'isSpam' => false,
+            'id' => 123,
+            'forum' => get_option( 'disqus_forum_url' ),
+        ];
+        $data = $this->call_comment_data_from_post( $post );
+        $this->assertStringStartsWith( 'anonymized-', $data['comment_author_email'] );
+        $this->assertStringEndsWith( '@disqus.com', $data['comment_author_email'] );
+    }
+
+    public function test_email_from_author_id() {
+        $post = [
+            'thread' => [ 'id' => 1, 'identifiers' => [ '1' ] ],
+            'author' => [ 'id' => 42 ],
+            'parent' => null,
+            'ipAddress' => '127.0.0.1',
+            'raw_message' => 'Test',
+            'createdAt' => '2020-01-01 00:00:00',
+            'isApproved' => true,
+            'isDeleted' => false,
+            'isSpam' => false,
+            'id' => 123,
+            'forum' => get_option( 'disqus_forum_url' ),
+        ];
+        $data = $this->call_comment_data_from_post( $post );
+        $this->assertEquals( 'user-42@disqus.com', $data['comment_author_email'] );
+    }
+
+    public function test_email_when_no_author() {
+        $post = [
+            'thread' => [ 'id' => 1, 'identifiers' => [ '1' ] ],
+            'author' => null,
+            'parent' => null,
+            'ipAddress' => '127.0.0.1',
+            'raw_message' => 'Test',
+            'createdAt' => '2020-01-01 00:00:00',
+            'isApproved' => true,
+            'isDeleted' => false,
+            'isSpam' => false,
+            'id' => 123,
+            'forum' => get_option( 'disqus_forum_url' ),
+        ];
+        $data = $this->call_comment_data_from_post( $post );
+        $this->assertStringEndsWith( '@disqus.com', $data['comment_author_email'] );
+        $this->assertNotEmpty( $data['comment_author_email'] );
+    }
+}


### PR DESCRIPTION
## Description  
Added some safeguards and default values if the Post's `author` is `null`.

## Motivation and Context  
https://github.com/disqus/disqus-wordpress-plugin/issues/140

## How Has This Been Tested?  
Added unit test for `comment_data_from_post` function

## Screenshots (if appropriate):  

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have updated the documentation accordingly.   
- [x] All new and existing tests passed.  
