### PR TITLE
Fix various conditions missing type checks

### DIFF
--- a/disqus/admin/class-disqus-admin.php
+++ b/disqus/admin/class-disqus-admin.php
@@ -159,7 +159,7 @@ class Disqus_Admin {
      */
     public function dsq_filter_rest_url( $rest_url ) {
         $rest_url_parts = parse_url( $rest_url );
-        if ( array_key_exists( 'host', $rest_url_parts ) ) {
+        if ( is_array( $rest_url_parts ) && array_key_exists( 'host', $rest_url_parts ) ) {
             $rest_host = $rest_url_parts['host'];
             if ( array_key_exists( 'port', $rest_url_parts ) ) {
                 $rest_host .= ':' . $rest_url_parts['port'];

--- a/disqus/rest-api/class-disqus-rest-api.php
+++ b/disqus/rest-api/class-disqus-rest-api.php
@@ -499,7 +499,7 @@ class Disqus_Rest_Api {
         }
 
         // Add additional non-database options here.
-        $settings['disqus_installed'] = trim( $settings['disqus_forum_url'] ) !== '';
+        $settings['disqus_installed'] = isset( $settings['disqus_forum_url'] ) && trim( $settings['disqus_forum_url'] ) !== '';
 
         return $settings;
     }

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -56,4 +56,26 @@ class Test_Admin extends WP_UnitTestCase {
         $this->assertEquals( $init_url, $rest_url );
     }
 
+    /**
+     * Test that parse_url failure doesn't cause array_key_exists error.
+     */
+    function test_dsq_filter_rest_url_malformed_url() {
+        $admin = new Disqus_Admin( 'disqus', '0.0.0', 'foo' );
+
+        // These malformed URLs should not cause PHP errors
+        $malformed_urls = [
+            'http:///wp-json/',
+            '://example.com/wp-json/',
+            'http://exa[mple.com/wp-json/',
+            '/wp-json/',
+            ''
+        ];
+
+        foreach ( $malformed_urls as $url ) {
+            $result = $admin->dsq_filter_rest_url( $url );
+            // Should return the original URL unchanged when parse_url fails
+            $this->assertEquals( $url, $result );
+        }
+    }
+
 }


### PR DESCRIPTION
## Description  

- In `Disqus_Admin::dsq_filter_rest_url()`, ensure `parse_url()` returns an array before calling `array_key_exists()` to avoid fatal errors on malformed URLs.
- In `Disqus_Rest_Api::get_settings()`, add `isset()` check on `disqus_forum_url` to prevent a warning from passing `null` to `trim()`.
- Add test to verify malformed REST URLs do not raise errors.

## Motivation and Context  
Fixes #141

## How Has This Been Tested?  
Added new test case and manually verified changes.

## Screenshots (if appropriate):  

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have updated the documentation accordingly.   
- [X] All new and existing tests passed.  
