### PR TITLE
Add check to prevent `md5` from running with no author name

### DIFF
--- a/disqus/rest-api/class-disqus-rest-api.php
+++ b/disqus/rest-api/class-disqus-rest-api.php
@@ -786,7 +786,8 @@ class Disqus_Rest_Api {
             if ( isset( $author['email'] ) ) {
                 $author_email = $author['email'];
             } elseif ( isset( $author['isAnonymous'] ) && $author['isAnonymous'] ) {
-                $author_email = 'anonymized-' . md5( $author['name'] ) . '@disqus.com';
+                $author_name = isset( $author['name'] ) && null !== $author['name'] ? $author['name'] : 'anonymous';
+                $author_email = 'anonymized-' . md5( $author_name ) . '@disqus.com';
             } elseif ( isset( $author['id'] ) ) {
                 $author_email = 'user-' . $author['id'] . '@disqus.com';
             }


### PR DESCRIPTION
## Description  
These changes add an additional check to prevent the `md5()` function from running with a `null` first parameter.

## Motivation and Context  
https://github.com/disqus/disqus-wordpress-plugin/issues/140#issuecomment-3720625915

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have updated the documentation accordingly.   
- [x] All new and existing tests passed.  
