### PR TITLE
Bump to v3.1.4, Marketing Changes, and Update Tests Up to WP 6.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         php: ["7.4", "8.0", "8.1", "8.2"]
         mysql: ["5.7", "8.0"]
-        wordpress: ["6.8", "6.7", "6.6", "6.5", "5.9"]
+        wordpress: ["6.9", "6.8", "6.7", "6.6", "6.5", "5.9"]
 
     steps:
       - name: Checkout code

--- a/disqus/README.txt
+++ b/disqus/README.txt
@@ -3,7 +3,7 @@ Contributors: disqus, alexkingorg, crowdfavorite, zeeg, tail, thetylerhayes, rya
 Tags: disqus, comments, engagement, threaded, email, notification, spam, avatars, community, profile, widget
 Requires at least: 4.4
 Tested up to: 6.8
-Stable tag: 3.1.3
+Stable tag: 3.1.4
 Requires PHP: 5.6
 
 Disqus is the web's most popular comment system. Use Disqus to increase engagement, retain readers, and grow your audience. **NEW: Disqus Polls – Engage your audiences with interactive polls, and seamlessly install them on your site.**
@@ -128,6 +128,9 @@ Go to [https://disqus.com/help/wordpress](https://disqus.com/help/wordpress)
 11. Moderate by Email Notifications
 
 == Changelog ==
+= 3.1.4 =
+* Added dismissible admin notice explaining free version ads and paid plan options
+
 = 3.1.3 =
 * Fixed bug with Disqus SSO and Gravatar Images
 * Switched DISQUSVERSION to constant (issue #139)

--- a/disqus/README.txt
+++ b/disqus/README.txt
@@ -2,7 +2,7 @@
 Contributors: disqus, alexkingorg, crowdfavorite, zeeg, tail, thetylerhayes, ryanv12, iamfrancisyo, brevityness, tterb, chrisjtang
 Tags: disqus, comments, engagement, threaded, email, notification, spam, avatars, community, profile, widget
 Requires at least: 4.4
-Tested up to: 6.8
+Tested up to: 6.9
 Stable tag: 3.1.4
 Requires PHP: 5.6
 

--- a/disqus/README.txt
+++ b/disqus/README.txt
@@ -130,6 +130,7 @@ Go to [https://disqus.com/help/wordpress](https://disqus.com/help/wordpress)
 == Changelog ==
 = 3.1.4 =
 * Added dismissible admin notice explaining free version ads and paid plan options
+* Fixed deprecation warning when syncing comments with null author name
 
 = 3.1.3 =
 * Fixed bug with Disqus SSO and Gravatar Images

--- a/disqus/admin/css/disqus-admin.css
+++ b/disqus/admin/css/disqus-admin.css
@@ -3,6 +3,31 @@
  * included in this file.
  */
 
+/* Disqus Ads Notice */
+.disqus-ads-notice {
+    border-left-color: #2e9fff;
+    background: linear-gradient(135deg, #f0f8ff 0%, #ffffff 100%);
+}
+
+.disqus-ads-notice p {
+    font-size: 14px;
+    line-height: 1.6;
+}
+
+.disqus-ads-notice strong {
+    color: #1a1a1a;
+}
+
+.disqus-ads-notice a {
+    color: #2e9fff;
+    text-decoration: none;
+    font-weight: 500;
+    margin-left: 8px;
+}
+
+.disqus-ads-notice a:hover {
+    text-decoration: underline;
+}
 
 #wpadminbar #wp-admin-bar-disqus .ab-icon:before {
     content: "\f101";

--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Disqus for WordPress
  * Plugin URI:        https://disqus.com/
  * Description:       Disqus helps publishers increase engagement and build loyal audiences. Supports syncing comments to your database for easy backup.
- * Version:           3.1.3
+ * Version:           3.1.4
  * Author:            Disqus
  * Author URI:        https://disqus.com/
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'DISQUS_VERSION', '3.1.3' );
+define( 'DISQUS_VERSION', '3.1.4' );
 
 /**
  * The code that runs during plugin activation (but not during updates).

--- a/disqus/includes/class-disqus.php
+++ b/disqus/includes/class-disqus.php
@@ -165,6 +165,8 @@ class Disqus {
         $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
         $this->loader->add_action( 'admin_menu', $plugin_admin, 'dsq_contruct_admin_menu' );
         $this->loader->add_action( 'admin_bar_menu', $plugin_admin, 'dsq_construct_admin_bar', 999 );
+        $this->loader->add_action( 'admin_notices', $plugin_admin, 'dsq_display_ads_notice' );
+        $this->loader->add_action( 'wp_ajax_disqus_dismiss_ads_notice', $plugin_admin, 'dsq_dismiss_ads_notice' );
     }
 
     /**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 3.1.4
 * Added dismissible admin notice explaining free version ads and paid plan options
+* Fixed deprecation warning when syncing comments with null author name
 
 ### 3.1.3
 * Fixed bug with Disqus SSO and Gravatar Images

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.1.4
+* Added dismissible admin notice explaining free version ads and paid plan options
+
 ### 3.1.3
 * Fixed bug with Disqus SSO and Gravatar Images
 * Switched DISQUSVERSION to constant (issue #139)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 3.1.4
 * Added dismissible admin notice explaining free version ads and paid plan options
 * Fixed deprecation warning when syncing comments with null author name
+* Tested up to WP 6.9
 
 ### 3.1.3
 * Fixed bug with Disqus SSO and Gravatar Images

--- a/frontend/src/ts/components/WhatsNew.tsx
+++ b/frontend/src/ts/components/WhatsNew.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
 import { pricingPolls } from '../constants/links';
 
-const latestVersion: String = '3.1.3';
+const latestVersion: String = '3.1.4';
 const updates: Array<String> = [
-    'Fixed bug with Disqus SSO and Gravatar Images',
-    'Switched DISQUSVERSION to constant',
-    'Fixed comment data issue if post author is null',
-    'Fixed various conditions missing type checks',
+    'Clarify Free Plan Ads',
 ]
 
 const WhatsNew: React.FC = () => {

--- a/frontend/src/ts/components/WhatsNew.tsx
+++ b/frontend/src/ts/components/WhatsNew.tsx
@@ -3,7 +3,8 @@ import { pricingPolls } from '../constants/links';
 
 const latestVersion: String = '3.1.4';
 const updates: Array<String> = [
-    'Clarify Free Plan Ads',
+    'Added dismissible admin notice explaining free version ads and paid plan options',
+    'Fixed deprecation warning when syncing comments with null author name',
 ]
 
 const WhatsNew: React.FC = () => {
@@ -18,9 +19,6 @@ const WhatsNew: React.FC = () => {
             <div className={`${showWhatsNew ? '' : ' hidden'}`}>
                 <ul>
                     {updates.map((update, index) => <li key={index}>{update}</li>)}
-                <li>
-                    <a href={pricingPolls} key='pricing-link'>Get started with Disqus Polls today</a>
-                </li>
                 </ul>
             </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "disqus-wordpress-plugin",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "A WordPress plugin that allows site owners to easily replace the default commenting system with Disqus",
   "main": "frontend/src/js/index.js",
   "scripts": {


### PR DESCRIPTION
## Description  
* Added dismissible admin notice explaining free version ads and paid plan options
* Tested up to WP 6.9
* Bump version to v3.1.4

## Motivation and Context  
Marketing updates and general plugin maintenance

## How Has This Been Tested?  
Manual testing + automated testing suite

## Screenshots (if appropriate):  

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have updated the documentation accordingly.   
- [x] All new and existing tests passed.  
